### PR TITLE
feat: add .github/workflows/main-push-guard.yml direct-push enforcement

### DIFF
--- a/.github/workflows/main-push-guard.yml
+++ b/.github/workflows/main-push-guard.yml
@@ -1,0 +1,162 @@
+name: Main Push Guard
+
+# Enforcement workflow: triggers on any push to main in THIS repository.
+# Purpose: reject direct pushes that bypass the PR review process.
+#
+# NOTE: The reusable build+push workflow lives at workflows/main-push-guard.yml
+# and is invoked by downstream repos via workflow_call after their own merge.
+# This file is the in-repo enforcement guard for ci-workflows itself.
+
+on:
+  push:
+    branches:
+      - main
+
+# Prevent concurrent guard runs — serialise to avoid double-reverts.
+concurrency:
+  group: main-push-guard
+  cancel-in-progress: false
+
+permissions:
+  contents: write
+  issues: write
+
+env:
+  MCP_URL: http://macmini-devserver.taile324e7.ts.net:8008
+
+jobs:
+  guard:
+    name: Enforce PR-only merges to main
+    runs-on: [self-hosted, macmini]
+    timeout-minutes: 10
+    steps:
+      # -----------------------------------------------------------------------
+      # 1. Detect whether the push arrived from a merged pull request
+      # -----------------------------------------------------------------------
+      - name: Detect PR-origin of push
+        id: detect
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          COMMIT_SHA="${{ github.sha }}"
+          COMMIT_MSG="${{ github.event.head_commit.message }}"
+
+          echo "Commit SHA  : ${COMMIT_SHA}"
+          echo "Commit msg  : ${COMMIT_MSG}"
+
+          # Pattern 1: GitHub standard merge commit — "Merge pull request #NNN"
+          if echo "${COMMIT_MSG}" | grep -qE "^Merge pull request #[0-9]+"; then
+            echo "Detected via: merge-commit pattern"
+            echo "is_pr_merge=true" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          # Pattern 2: Squash merge — "(#NNN)" at end of first line
+          if echo "${COMMIT_MSG}" | grep -qE "\(#[0-9]+\)$"; then
+            echo "Detected via: squash-merge pattern"
+            echo "is_pr_merge=true" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          # Pattern 3: Rebase merge — check GitHub API for associated PRs
+          PR_COUNT=$(gh api \
+            "repos/${{ github.repository }}/commits/${COMMIT_SHA}/pulls" \
+            --jq 'length' 2>/dev/null || echo "0")
+          echo "API-associated PRs: ${PR_COUNT}"
+
+          if [ "${PR_COUNT}" -gt "0" ]; then
+            echo "Detected via: GitHub API associated PRs"
+            echo "is_pr_merge=true" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          echo "is_pr_merge=false" >> "$GITHUB_OUTPUT"
+          echo "::warning::No PR association found — treating as direct push violation"
+
+      # -----------------------------------------------------------------------
+      # 2a. PR merge — allow (nothing to do)
+      # -----------------------------------------------------------------------
+      - name: Allow — push is from a merged PR
+        if: steps.detect.outputs.is_pr_merge == 'true'
+        run: echo "Push originated from a merged pull request. Proceeding."
+
+      # -----------------------------------------------------------------------
+      # 2b. Direct push — revert, create issue, notify MCP, fail loudly
+      # -----------------------------------------------------------------------
+      - name: Revert the direct push
+        if: steps.detect.outputs.is_pr_merge == 'false'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          git config --global user.email "github-actions[bot]@users.noreply.github.com"
+          git config --global user.name "github-actions[bot]"
+
+          git clone "https://x-access-token:${GH_TOKEN}@github.com/${{ github.repository }}.git" repo
+          cd repo
+
+          # Revert the offending commit without opening an editor
+          git revert --no-edit "${{ github.sha }}"
+
+          git push origin main
+          echo "Revert pushed to main."
+
+      - name: Create GitHub issue for direct-push violation
+        if: steps.detect.outputs.is_pr_merge == 'false'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          ACTOR="${{ github.actor }}"
+          SHA="${{ github.sha }}"
+          SHORT_SHA="${SHA:0:8}"
+          COMMIT_MSG="${{ github.event.head_commit.message }}"
+          RUN_URL="https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+
+          gh issue create \
+            --repo "${{ github.repository }}" \
+            --title "Direct push violation on main by @${ACTOR} (${SHORT_SHA})" \
+            --body "## Direct Push Violation Detected
+
+          A commit was pushed directly to \`main\` without going through a pull request. This violates the PR-only merge policy.
+
+          **Details:**
+          - **Actor:** @${ACTOR}
+          - **Commit SHA:** \`${SHA}\`
+          - **Commit message:** ${COMMIT_MSG}
+          - **Workflow run:** ${RUN_URL}
+
+          **Action taken:** The commit has been automatically reverted.
+
+          **Required action:** @${ACTOR} — please open a pull request and go through code review before merging to \`main\`." \
+            --label "direct-push-violation" 2>/dev/null \
+            || echo "::warning::Failed to create issue (label may not exist in this repo yet)"
+
+      - name: Notify MCP journal of direct-push violation
+        if: steps.detect.outputs.is_pr_merge == 'false'
+        run: |
+          ACTOR="${{ github.actor }}"
+          SHA="${{ github.sha }}"
+          SHORT_SHA="${SHA:0:8}"
+          REPO="${{ github.repository }}"
+          RUN_URL="https://github.com/${REPO}/actions/runs/${{ github.run_id }}"
+
+          # Best-effort — do not fail the workflow if MCP is unreachable
+          curl -sf --max-time 10 -X POST "${MCP_URL}/api/journal" \
+            -H "Content-Type: application/json" \
+            -H "X-Service-Key: ${{ secrets.MCP_SERVICE_KEY }}" \
+            -d "{
+              \"agent\": \"github-actions\",
+              \"event\": \"direct_push_violation\",
+              \"payload\": {
+                \"actor\": \"${ACTOR}\",
+                \"sha\": \"${SHA:0:8}\",
+                \"repo\": \"${REPO}\",
+                \"message\": \"Direct push by ${ACTOR} on ${REPO} commit ${SHORT_SHA} — auto-reverted. Run: ${RUN_URL}\"
+              }
+            }" > /dev/null 2>&1 \
+            || echo "::warning::MCP journal notification failed (non-fatal)"
+
+      - name: Fail workflow to surface the violation visibly
+        if: steps.detect.outputs.is_pr_merge == 'false'
+        run: |
+          echo "::error::Direct push to main detected. Commit ${{ github.sha }} by @${{ github.actor }} has been reverted automatically. Use a pull request to merge changes to main."
+          exit 1


### PR DESCRIPTION
## Summary

- Adds `.github/workflows/main-push-guard.yml` — the enforcement guard that runs in **this repository** on every push to `main`
- Distinct from the existing `workflows/main-push-guard.yml` reusable workflow (which is a `workflow_call` build+push pipeline for downstream repos)
- Implements item 7b9ae1f3-47f0-4b31-861d-e49eced3c8ae and design doc 37421058

## What this workflow does

**Triggers on:** `push` to `main`

**Logic:**
1. Checks whether the push came from a merged PR using three detection methods:
   - Merge commit pattern: `Merge pull request #NNN`
   - Squash merge pattern: commit message ending with `(#NNN)`
   - GitHub API: `GET /repos/:owner/:repo/commits/:sha/pulls` returns associated PRs
2. **If PR merge:** exits 0, allows the push
3. **If direct push:**
   - Reverts the commit with `git revert --no-edit` and force-pushes to `main`
   - Creates a GitHub issue labelled `direct-push-violation` with the actor, SHA, and run link
   - Posts a `direct_push_violation` event to the MCP journal via `POST /api/journal` (uses `MCP_SERVICE_KEY` secret, best-effort — non-fatal if unreachable)
   - Fails the workflow with `exit 1` to make the violation visible in the Actions tab

## Secrets required

| Secret | Purpose |
|--------|---------|
| `GITHUB_TOKEN` | Built-in — used for git clone with write access and `gh issue create` |
| `MCP_SERVICE_KEY` | Optional — used for MCP journal notification; failure is non-fatal |

## Test plan

- [ ] Merge this PR via GitHub UI — verify the guard does not trigger (PR merge detected)
- [ ] After merge, attempt a direct push to main from a clone — verify revert commit appears, issue is created with `direct-push-violation` label, workflow fails
- [ ] Verify MCP journal receives the `direct_push_violation` event when `MCP_SERVICE_KEY` is configured

🤖 Generated with [Claude Code](https://claude.com/claude-code)