### PR TITLE
feat(deploy): add reusable deploy.yml with reliability gates (#6)

### DIFF
--- a/.github/workflows/contract-tests.yml
+++ b/.github/workflows/contract-tests.yml
@@ -1,0 +1,61 @@
+name: Contract Tests
+
+# Runs the qwickapps/ci-workflows#6 contract test suite on every PR.
+# The contract is the spine of every consumer's audit trail — a future
+# commit that breaks the validator (or the evidence-emit shape) would
+# silently disable downstream audit guarantees, so this gate is
+# mandatory.
+#
+# Tests:
+#   bash scripts/tests/contract.test.sh
+#     - validator: golden path on shipped deploy.yml
+#     - validator: 11 mutation rejections (missing job, broken needs:
+#       chain, missing input/output, evidence-without-always(), etc.)
+#     - deploy-evidence.sh: schema-required field presence
+#     - deploy-evidence.sh: optional-field omission
+#     - deploy-evidence.sh: caller_metadata round-trip
+#     - deploy-evidence.sh: input validation rejection cases
+
+on:
+  pull_request:
+    paths:
+      - 'workflows/deploy.yml'
+      - 'scripts/deploy-evidence.sh'
+      - 'scripts/validate-deploy-contract.sh'
+      - 'scripts/tests/**'
+      - '.github/workflows/contract-tests.yml'
+  push:
+    branches: [main, dev]
+    paths:
+      - 'workflows/deploy.yml'
+      - 'scripts/deploy-evidence.sh'
+      - 'scripts/validate-deploy-contract.sh'
+      - 'scripts/tests/**'
+
+permissions:
+  contents: read
+
+jobs:
+  contract:
+    name: deploy.yml contract tests
+    runs-on: [self-hosted, linux]
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Install PyYAML + jq (for the validator and test assertions)
+        run: |
+          # PyYAML drives validate-deploy-contract.sh; jq drives the
+          # deploy-evidence.sh assertions. Self-hosted runners typically
+          # ship both, but pin the install so a runner-image drift
+          # doesn't silently mask test failures.
+          if ! python3 -c "import yaml" >/dev/null 2>&1; then
+            python3 -m pip install --user PyYAML
+          fi
+          if ! command -v jq >/dev/null 2>&1; then
+            echo "::error::jq is required on the runner"
+            exit 2
+          fi
+
+      - name: Run contract test suite
+        run: bash scripts/tests/contract.test.sh

--- a/scripts/deploy-evidence.sh
+++ b/scripts/deploy-evidence.sh
@@ -1,0 +1,145 @@
+#!/usr/bin/env bash
+#
+# deploy-evidence.sh — emit the audit evidence JSON for a deploy run.
+#
+# Closes part of qwickapps/ci-workflows#6 ("Workflow outputs include
+# commit, image digest, target, actor, validation result, and
+# rollback target"). The reusable deploy.yml's evidence job calls
+# this script after the deploy completes (success OR failure) and
+# uploads the resulting JSON as a workflow artifact.
+#
+# Usage:
+#   ./deploy-evidence.sh \
+#     --commit          <git-sha> \
+#     --target          <env-label> \
+#     --actor           <github-actor> \
+#     --image-ref       <ghcr.io/owner/img:tag> \
+#     [--image-digest   <sha256:...>] \
+#     [--rollback-target <ghcr.io/owner/img:prev>] \
+#     --deploy-result   <success|failure|cancelled|skipped> \
+#     --validation      <pass|fail|skipped> \
+#     [--extra-json     <{"key":"value"}>]
+#
+# Emits the evidence record to stdout (single-line JSON) so callers
+# that don't want the file form can pipe it elsewhere. Stderr carries
+# the human-readable progress; stdout stays JSON-only.
+
+set -euo pipefail
+
+COMMIT=""
+TARGET=""
+ACTOR=""
+IMAGE_REF=""
+IMAGE_DIGEST=""
+ROLLBACK_TARGET=""
+DEPLOY_RESULT=""
+VALIDATION=""
+EXTRA_JSON='{}'
+
+usage() {
+  cat >&2 <<USAGE
+usage: $0 \\
+  --commit          <git-sha> \\
+  --target          <env-label> \\
+  --actor           <github-actor> \\
+  --image-ref       <ghcr.io/owner/img:tag> \\
+  [--image-digest   <sha256:...>] \\
+  [--rollback-target <ghcr.io/owner/img:prev>] \\
+  --deploy-result   <success|failure|cancelled|skipped> \\
+  --validation      <pass|fail|skipped> \\
+  [--extra-json     <{"key":"value"}>]
+USAGE
+}
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --commit)          COMMIT="$2";          shift 2 ;;
+    --target)          TARGET="$2";          shift 2 ;;
+    --actor)           ACTOR="$2";           shift 2 ;;
+    --image-ref)       IMAGE_REF="$2";       shift 2 ;;
+    --image-digest)    IMAGE_DIGEST="$2";    shift 2 ;;
+    --rollback-target) ROLLBACK_TARGET="$2"; shift 2 ;;
+    --deploy-result)   DEPLOY_RESULT="$2";   shift 2 ;;
+    --validation)      VALIDATION="$2";      shift 2 ;;
+    --extra-json)      EXTRA_JSON="$2";      shift 2 ;;
+    -h|--help)         usage; exit 0 ;;
+    *)
+      echo "::error::Unknown option: $1" >&2
+      usage
+      exit 2
+      ;;
+  esac
+done
+
+# ── Validate required arguments ──────────────────────────────────────────
+for var in COMMIT TARGET ACTOR IMAGE_REF DEPLOY_RESULT VALIDATION; do
+  if [ -z "${!var}" ]; then
+    flag="$(printf '%s' "$var" | tr '[:upper:]_' '[:lower:]-')"
+    echo "::error::missing required argument: --$flag" >&2
+    usage
+    exit 2
+  fi
+done
+
+case "$VALIDATION" in
+  pass|fail|skipped) ;;
+  *)
+    echo "::error::invalid --validation '$VALIDATION'; must be pass|fail|skipped" >&2
+    exit 2
+    ;;
+esac
+
+case "$DEPLOY_RESULT" in
+  success|failure|cancelled|skipped) ;;
+  *)
+    echo "::error::invalid --deploy-result '$DEPLOY_RESULT'; must be success|failure|cancelled|skipped" >&2
+    exit 2
+    ;;
+esac
+
+# Validate the extra-json blob actually parses; reject silently-broken
+# payloads at emit time rather than landing them in the audit log.
+if ! printf '%s' "$EXTRA_JSON" | jq -e . >/dev/null 2>&1; then
+  echo "::error::--extra-json is not valid JSON: $EXTRA_JSON" >&2
+  exit 2
+fi
+# And it must be an object (not an array, number, etc.) so
+# .caller_metadata is mergeable.
+if [ "$(printf '%s' "$EXTRA_JSON" | jq -r 'type')" != "object" ]; then
+  echo "::error::--extra-json must be a JSON object; got $(printf '%s' "$EXTRA_JSON" | jq -r 'type')" >&2
+  exit 2
+fi
+
+# ── Build the envelope ──────────────────────────────────────────────────
+NOW="$(date -u +%Y-%m-%dT%H:%M:%S.000Z)"
+
+jq -nc \
+  --arg commit          "$COMMIT" \
+  --arg target          "$TARGET" \
+  --arg actor           "$ACTOR" \
+  --arg image_ref       "$IMAGE_REF" \
+  --arg image_digest    "$IMAGE_DIGEST" \
+  --arg rollback_target "$ROLLBACK_TARGET" \
+  --arg deploy_result   "$DEPLOY_RESULT" \
+  --arg validation      "$VALIDATION" \
+  --argjson extra       "$EXTRA_JSON" \
+  --arg emitted_at      "$NOW" \
+  '
+  {
+    commit:            $commit,
+    target:            $target,
+    actor:             $actor,
+    image_ref:         $image_ref,
+    deploy_result:     $deploy_result,
+    validation_result: $validation,
+    emitted_at:        $emitted_at
+  }
+  # Optional fields: only emit the key when the caller supplied a value.
+  # Bare `select(. != "")` would yield empty and collapse the whole
+  # object, so we splice in conditionally.
+  + (if $image_digest    != "" then {image_digest:    $image_digest}    else {} end)
+  + (if $rollback_target != "" then {rollback_target: $rollback_target} else {} end)
+  # Caller metadata under a separate key so it cannot collide with the
+  # contract-required outputs.
+  + (if ($extra | length) > 0 then {caller_metadata: $extra} else {} end)
+  '

--- a/scripts/tests/contract.test.sh
+++ b/scripts/tests/contract.test.sh
@@ -1,0 +1,169 @@
+#!/usr/bin/env bash
+#
+# Unit tests for ci-workflows#6 deploy contract:
+#   - workflows/deploy.yml conforms (validate-deploy-contract.sh)
+#   - mutated copies fail loudly (negative cases)
+#   - scripts/deploy-evidence.sh emits the right shape
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+SCRIPTS_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
+ROOT_DIR="$(cd "$SCRIPTS_DIR/.." && pwd)"
+DEPLOY_YML="$ROOT_DIR/workflows/deploy.yml"
+EVIDENCE="$SCRIPTS_DIR/deploy-evidence.sh"
+VALIDATOR="$SCRIPTS_DIR/validate-deploy-contract.sh"
+
+TMPDIR_TEST="$(mktemp -d)"
+trap 'rm -rf "$TMPDIR_TEST"' EXIT
+
+pass=0
+fail=0
+assert() {
+  local desc="$1"; shift
+  if "$@"; then
+    echo "  PASS: $desc"
+    pass=$((pass + 1))
+  else
+    echo "  FAIL: $desc"
+    fail=$((fail + 1))
+  fi
+}
+
+# ── Contract validator: golden path ─────────────────────────────────────
+echo "== validator: workflows/deploy.yml conforms =="
+
+assert "validator passes on shipped deploy.yml" \
+  bash "$VALIDATOR" "$DEPLOY_YML"
+
+# ── Contract validator: negative cases ──────────────────────────────────
+echo "== validator: mutated copies fail =="
+
+# Helper: copy deploy.yml into TMPDIR_TEST, run a python script that
+# mutates a single key, then assert the validator rejects.
+mutate_and_validate() {
+  local desc="$1"
+  local mutator_script="$2"
+  local copy="$TMPDIR_TEST/deploy.yml"
+  cp "$DEPLOY_YML" "$copy"
+  python3 - "$copy" <<PY
+import sys, yaml
+path = sys.argv[1]
+with open(path) as fh:
+    doc = yaml.safe_load(fh)
+$mutator_script
+with open(path, "w") as fh:
+    yaml.safe_dump(doc, fh)
+PY
+  if bash "$VALIDATOR" "$copy" >/dev/null 2>&1; then
+    echo "  FAIL: $desc (validator should have rejected the mutation)"
+    fail=$((fail + 1))
+  else
+    echo "  PASS: $desc"
+    pass=$((pass + 1))
+  fi
+}
+
+mutate_and_validate "removing tests job rejects" '
+del doc["jobs"]["tests"]
+'
+mutate_and_validate "removing evidence job rejects" '
+del doc["jobs"]["evidence"]
+'
+mutate_and_validate "removing build job rejects" '
+del doc["jobs"]["build"]
+'
+mutate_and_validate "removing deploy job rejects" '
+del doc["jobs"]["deploy"]
+'
+mutate_and_validate "removing validate job rejects" '
+del doc["jobs"]["validate"]
+'
+mutate_and_validate "deploy not depending on build rejects" '
+doc["jobs"]["deploy"]["needs"] = "preflight"
+'
+mutate_and_validate "validate not depending on deploy rejects" '
+doc["jobs"]["validate"]["needs"] = "build"
+'
+mutate_and_validate "evidence missing always() rejects" '
+doc["jobs"]["evidence"]["if"] = "needs.preflight.result == \"success\""
+'
+mutate_and_validate "missing image_ref input rejects" '
+del doc[True]["workflow_call"]["inputs"]["image_ref"]
+'
+mutate_and_validate "missing commit output rejects" '
+del doc[True]["workflow_call"]["outputs"]["commit"]
+'
+mutate_and_validate "test_command marked not-required rejects" '
+doc[True]["workflow_call"]["inputs"]["test_command"]["required"] = False
+'
+
+# ── Evidence script: happy path + required field set ────────────────────
+echo "== deploy-evidence: happy path =="
+
+EV_OUT="$($EVIDENCE \
+  --commit abcdef1 \
+  --target dev \
+  --actor operator-test \
+  --image-ref ghcr.io/qwickapps/img-foo:1.2.3 \
+  --image-digest sha256:abc123 \
+  --rollback-target ghcr.io/qwickapps/img-foo:1.2.2 \
+  --deploy-result success \
+  --validation pass)"
+
+assert "evidence is single-line JSON" \
+  bash -c "echo '$EV_OUT' | jq -e . >/dev/null"
+
+# All AC-required output fields present.
+for field in commit target actor image_ref deploy_result validation_result emitted_at; do
+  assert "evidence includes $field" \
+    bash -c "echo '$EV_OUT' | jq -e 'has(\"$field\")' >/dev/null"
+done
+
+assert "image_digest round-trips when supplied" \
+  bash -c "echo '$EV_OUT' | jq -re '.image_digest' | grep -q '^sha256:abc123\$'"
+assert "rollback_target round-trips when supplied" \
+  bash -c "echo '$EV_OUT' | jq -re '.rollback_target' | grep -q '^ghcr.io/qwickapps/img-foo:1.2.2\$'"
+
+# ── Evidence script: optional-field omission ────────────────────────────
+echo "== deploy-evidence: optional-field omission =="
+
+EV_NO_DIGEST="$($EVIDENCE \
+  --commit abc --target dev --actor t --image-ref x:1 \
+  --deploy-result success --validation skipped)"
+
+assert "evidence omits image_digest when empty" \
+  bash -c "echo '$EV_NO_DIGEST' | jq -e 'has(\"image_digest\") | not' >/dev/null"
+assert "evidence omits rollback_target when empty" \
+  bash -c "echo '$EV_NO_DIGEST' | jq -e 'has(\"rollback_target\") | not' >/dev/null"
+assert "evidence omits caller_metadata when empty" \
+  bash -c "echo '$EV_NO_DIGEST' | jq -e 'has(\"caller_metadata\") | not' >/dev/null"
+
+# ── Evidence script: caller-metadata merge ──────────────────────────────
+echo "== deploy-evidence: caller_metadata =="
+
+EV_META="$($EVIDENCE \
+  --commit abc --target dev --actor t --image-ref x:1 \
+  --deploy-result success --validation pass \
+  --extra-json '{"branch":"feat/x","run":42}')"
+
+assert "caller_metadata round-trips" \
+  bash -c "echo '$EV_META' | jq -e '.caller_metadata.branch == \"feat/x\" and .caller_metadata.run == 42' >/dev/null"
+
+# ── Evidence script: input validation ───────────────────────────────────
+echo "== deploy-evidence: input validation =="
+
+assert "missing --commit rejected" \
+  bash -c "$EVIDENCE --target d --actor t --image-ref x:1 --deploy-result success --validation pass >/dev/null 2>&1; rc=\$?; test \$rc -eq 2"
+assert "invalid --validation rejected" \
+  bash -c "$EVIDENCE --commit a --target d --actor t --image-ref x:1 --deploy-result success --validation explosion >/dev/null 2>&1; rc=\$?; test \$rc -eq 2"
+assert "invalid --deploy-result rejected" \
+  bash -c "$EVIDENCE --commit a --target d --actor t --image-ref x:1 --deploy-result yes --validation pass >/dev/null 2>&1; rc=\$?; test \$rc -eq 2"
+assert "non-object --extra-json rejected" \
+  bash -c "$EVIDENCE --commit a --target d --actor t --image-ref x:1 --deploy-result success --validation pass --extra-json '[1,2,3]' >/dev/null 2>&1; rc=\$?; test \$rc -eq 2"
+assert "malformed --extra-json rejected" \
+  bash -c "$EVIDENCE --commit a --target d --actor t --image-ref x:1 --deploy-result success --validation pass --extra-json 'not json' >/dev/null 2>&1; rc=\$?; test \$rc -eq 2"
+
+echo ""
+echo "Tests: $pass passed, $fail failed"
+[ "$fail" -eq 0 ]

--- a/scripts/validate-deploy-contract.sh
+++ b/scripts/validate-deploy-contract.sh
@@ -28,19 +28,23 @@ if [ ! -f "$DEPLOY_FILE" ]; then
   exit 2
 fi
 
-# We use python3 + the yaml stdlib (PyYAML, available on every
-# self-hosted runner via pip; falls back to a manual parse if not
-# installed) rather than yq to keep the runtime dependency surface
-# down to "python3, which we already need for everything else."
-if ! python3 -c "import yaml" >/dev/null 2>&1; then
-  echo "::error::PyYAML is required to validate the deploy contract; pip install PyYAML" >&2
-  exit 2
-fi
+# We use python3 + PyYAML rather than yq to keep the runtime
+# dependency surface down to "python3, which we already need for
+# everything else." The import is checked inside the heredoc so the
+# error message is the standard ImportError trace + a hint, not a
+# duplicate guard.
 
 # ── Drive the assertions in Python ───────────────────────────────────────
 python3 - "$DEPLOY_FILE" <<'PY'
 import sys
-import yaml
+try:
+    import yaml
+except ImportError:
+    sys.stderr.write(
+        "::error::PyYAML is required to validate the deploy contract; "
+        "install with `pip install PyYAML`\n"
+    )
+    sys.exit(2)
 
 path = sys.argv[1]
 with open(path, "r", encoding="utf-8") as fh:

--- a/scripts/validate-deploy-contract.sh
+++ b/scripts/validate-deploy-contract.sh
@@ -1,0 +1,161 @@
+#!/usr/bin/env bash
+#
+# validate-deploy-contract.sh — assert that workflows/deploy.yml has
+# all the required gates wired with strict `needs:` ordering. Closes
+# part of qwickapps/ci-workflows#6 ("contract tests proving required
+# gates and evidence outputs cannot be skipped by callers").
+#
+# The verification is intentionally simple: walk the YAML with
+# `yq` (or `python3 -c` as a fallback) and assert the structure.
+# The reason the test is at this layer is that GitHub Actions
+# reusable workflows aren't directly unit-testable — the only way
+# to prove the contract holds is to validate the workflow file
+# itself.
+#
+# Usage:
+#   ./validate-deploy-contract.sh [path/to/deploy.yml]
+#
+# Defaults to ../workflows/deploy.yml relative to the script.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+DEFAULT_DEPLOY="$(cd "$SCRIPT_DIR/.." && pwd)/workflows/deploy.yml"
+DEPLOY_FILE="${1:-$DEFAULT_DEPLOY}"
+
+if [ ! -f "$DEPLOY_FILE" ]; then
+  echo "::error::deploy.yml not found at $DEPLOY_FILE" >&2
+  exit 2
+fi
+
+# We use python3 + the yaml stdlib (PyYAML, available on every
+# self-hosted runner via pip; falls back to a manual parse if not
+# installed) rather than yq to keep the runtime dependency surface
+# down to "python3, which we already need for everything else."
+if ! python3 -c "import yaml" >/dev/null 2>&1; then
+  echo "::error::PyYAML is required to validate the deploy contract; pip install PyYAML" >&2
+  exit 2
+fi
+
+# ── Drive the assertions in Python ───────────────────────────────────────
+python3 - "$DEPLOY_FILE" <<'PY'
+import sys
+import yaml
+
+path = sys.argv[1]
+with open(path, "r", encoding="utf-8") as fh:
+    doc = yaml.safe_load(fh)
+
+errors: list[str] = []
+
+def fail(msg: str) -> None:
+    errors.append(msg)
+
+# 1. Must be a workflow_call (reusable) workflow.
+# YAML 1.1 quirk: the bare key `on` is parsed as the boolean True by
+# PyYAML's safe_load. Look it up under both keys so the validator
+# works regardless of which dialect parsed the file.
+on = None
+if isinstance(doc, dict):
+    on = doc.get("on")
+    if on is None:
+        on = doc.get(True)  # YAML 1.1 boolean key
+if isinstance(on, dict):
+    if "workflow_call" not in on:
+        fail("on.workflow_call missing — deploy.yml must be a reusable workflow")
+elif on is True or on == "workflow_call":
+    pass  # accept the shorthand form
+else:
+    fail("on: must be a mapping containing workflow_call")
+
+# 2. Required inputs (cannot be defaulted away).
+inputs = ((on or {}).get("workflow_call") or {}).get("inputs") or {}
+required_inputs = {
+    "target_environment": True,
+    "image_name":         True,
+    "image_ref":          True,
+    "test_command":       True,
+    "build_command":      True,
+    "deploy_command":     True,
+}
+for name, must_be_required in required_inputs.items():
+    spec = inputs.get(name)
+    if not isinstance(spec, dict):
+        fail(f"input.{name} missing")
+        continue
+    if must_be_required and not spec.get("required"):
+        fail(f"input.{name}.required must be true (cannot be defaulted away)")
+
+# 3. Required outputs (the AC explicitly enumerates these).
+outputs = ((on or {}).get("workflow_call") or {}).get("outputs") or {}
+for name in (
+    "commit", "image_digest", "target", "actor",
+    "validation_result", "rollback_target",
+):
+    if name not in outputs:
+        fail(f"output.{name} missing — required by AC")
+
+# 4. Required jobs in a strict needs chain.
+jobs = doc.get("jobs") or {}
+required_chain = [
+    ("preflight", None),
+    ("tests",     "preflight"),
+    ("build",     "tests"),
+    ("deploy",    "build"),
+    ("validate",  "deploy"),
+]
+for job_name, expected_dep in required_chain:
+    job = jobs.get(job_name)
+    if not isinstance(job, dict):
+        fail(f"job.{job_name} missing")
+        continue
+    if expected_dep is None:
+        continue
+    needs = job.get("needs")
+    if isinstance(needs, str):
+        needs_list = [needs]
+    elif isinstance(needs, list):
+        needs_list = needs
+    else:
+        needs_list = []
+    if expected_dep not in needs_list:
+        fail(
+            f"job.{job_name}.needs must include {expected_dep!r} "
+            f"(got {needs_list!r}) — without it a caller could disable the upstream gate"
+        )
+
+# 5. Evidence job must exist and depend on validate (so the audit
+# record reflects the validation outcome) and on preflight (to capture
+# the deploy context).
+evidence = jobs.get("evidence")
+if not isinstance(evidence, dict):
+    fail("job.evidence missing — required for AC ('evidence upload cannot be skipped')")
+else:
+    needs = evidence.get("needs") or []
+    if isinstance(needs, str):
+        needs = [needs]
+    for dep in ("preflight", "build", "deploy", "validate"):
+        if dep not in needs:
+            fail(f"job.evidence.needs must include {dep!r}")
+    if "if" not in evidence or "always()" not in str(evidence["if"]):
+        fail(
+            "job.evidence.if must include always() so failed deploys "
+            "still produce an audit record"
+        )
+    # The evidence step must include an actions/upload-artifact step.
+    steps = evidence.get("steps") or []
+    has_upload = any(
+        isinstance(s, dict) and "upload-artifact" in str(s.get("uses") or "")
+        for s in steps
+    )
+    if not has_upload:
+        fail("job.evidence must include an actions/upload-artifact step")
+
+if errors:
+    print("contract validation FAILED:", file=sys.stderr)
+    for err in errors:
+        print(f"  - {err}", file=sys.stderr)
+    sys.exit(1)
+
+print("contract validation OK: deploy.yml conforms to the qwickapps/ci-workflows#6 contract")
+PY

--- a/workflows/deploy.yml
+++ b/workflows/deploy.yml
@@ -28,6 +28,35 @@ name: Deploy (Reusable)
 # This workflow does NOT execute the deploy itself — the caller passes
 # the commands. The contract is "you wire up the commands; we enforce
 # the order, the evidence, and the audit shape."
+#
+# ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+# SECURITY: untrusted-input caveat — READ BEFORE INVOKING
+# ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+# The contract accepts shell-command strings (test_command,
+# build_command, deploy_command, validate_command, preflight_command).
+# GitHub Actions interpolates `${{ inputs.X }}` BEFORE the runner shell
+# sees it — values flow into the run script as raw text. That means:
+#
+#   *  CALLERS MUST NOT pass attacker-controlled data as any *_command
+#      input. Specifically: never pass `${{ github.event.pull_request.body }}`,
+#      issue/comment text, branch names, or any field that an external
+#      contributor can write to. Treat the *_command inputs the same
+#      way you would treat a secret: the values must come from the
+#      caller workflow file (committed code) or from a trusted secret.
+#
+#   *  CALLERS MUST NOT invoke this workflow from `pull_request_target`
+#      against forks. That trigger runs with the base-repo's token and
+#      secrets while checking out the forked HEAD — combining it with
+#      command-string inputs is a remote-code-execution shape. Use
+#      `pull_request` (which runs in fork context, no secrets) or gate
+#      `pull_request_target` to label-trusted PRs only.
+#
+#   *  Required inputs are validated for non-empty in preflight; this
+#      is a contract guard, not a security control. Defense-in-depth
+#      lives at the caller (where the *_command values come from).
+# ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+permissions: read-all  # callers explicitly grant additional scopes
 
 on:
   workflow_call:
@@ -81,6 +110,18 @@ on:
         required: false
         type: string
         default: '{}'
+      evidence_script_path:
+        description: |
+          Path to deploy-evidence.sh, relative to the caller's repo root.
+          Defaults to autodiscovery (.ci-workflows/scripts/... then scripts/...).
+          Set explicitly when vendoring this repo under a non-default
+          submodule path, or use the canonical .ci-workflows submodule
+          path. A future release will also ship a composite-action form
+          (qwickapps/ci-workflows#TBD) so callers can drop the vendoring
+          requirement entirely.
+        required: false
+        type: string
+        default: ''
     outputs:
       commit:
         description: 'Git sha of the deployed change'
@@ -101,6 +142,11 @@ on:
         description: 'Image ref displaced by this deploy'
         value: ${{ jobs.preflight.outputs.rollback_target }}
     secrets:
+      # Callers that need additional secrets (e.g. deploy keys, tag
+      # signing tokens) should reference this workflow with
+      # `secrets: inherit` so the full secret context flows through.
+      # The explicit declaration here is a backstop for callers that
+      # pass an explicit `secrets:` mapping.
       GHCR_PUSH_TOKEN:
         required: false
 
@@ -291,22 +337,31 @@ jobs:
           IMAGE_DIGEST:  ${{ needs.build.outputs.image_digest }}
           DEPLOY_RESULT: ${{ needs.deploy.result }}
           VALIDATION:    ${{ needs.validate.outputs.result }}
-          EXTRA_JSON:    ${{ inputs.evidence_extra_json }}
+          EXTRA_JSON:        ${{ inputs.evidence_extra_json }}
+          EXPLICIT_SCRIPT:   ${{ inputs.evidence_script_path }}
         run: |
-          chmod +x .ci-workflows/scripts/deploy-evidence.sh 2>/dev/null \
-            || chmod +x scripts/deploy-evidence.sh 2>/dev/null \
-            || true
-
-          # Resolve the script path: callers vendor this repo as
-          # .ci-workflows submodule; the script ships at
-          # .ci-workflows/scripts/deploy-evidence.sh. Direct-call
-          # consumers (this repo's own tests) use scripts/...
-          if [ -x .ci-workflows/scripts/deploy-evidence.sh ]; then
+          # Resolve the script path. Order:
+          #   1. caller-supplied evidence_script_path (the explicit
+          #      escape hatch for non-default vendoring layouts);
+          #   2. canonical submodule path (.ci-workflows/scripts/...);
+          #   3. direct-call layout (this repo's own tests).
+          # File is shipped 100755 on disk; chmod is unnecessary.
+          if [ -n "$EXPLICIT_SCRIPT" ]; then
+            if [ ! -x "$EXPLICIT_SCRIPT" ]; then
+              echo "::error::evidence_script_path='$EXPLICIT_SCRIPT' is not executable"
+              exit 2
+            fi
+            SCRIPT="$EXPLICIT_SCRIPT"
+          elif [ -x .ci-workflows/scripts/deploy-evidence.sh ]; then
             SCRIPT=".ci-workflows/scripts/deploy-evidence.sh"
           elif [ -x scripts/deploy-evidence.sh ]; then
             SCRIPT="scripts/deploy-evidence.sh"
           else
-            echo "::error::deploy-evidence.sh not found"
+            echo "::error::deploy-evidence.sh not found at any of:"
+            echo "  - \$evidence_script_path (input)"
+            echo "  - .ci-workflows/scripts/deploy-evidence.sh"
+            echo "  - scripts/deploy-evidence.sh"
+            echo "Set inputs.evidence_script_path to the path in your repo."
             exit 2
           fi
 

--- a/workflows/deploy.yml
+++ b/workflows/deploy.yml
@@ -1,0 +1,337 @@
+name: Deploy (Reusable)
+
+# Reusable deploy workflow that enforces the qwickapps/ci-workflows#6
+# reliability validation contract:
+#
+#   preflight  →  tests  →  build  →  deploy  →  validate  →  evidence
+#                                                              ↓
+#                                                         (rollback hook)
+#
+# Calling repos cannot skip preflight, tests, validation, or evidence
+# upload — each downstream job declares the upstream as `needs`, so
+# disabling any single step breaks the chain at workflow_call time.
+# This is the defense-in-depth lever for the parent epic
+# (raajkumars/qwickguard#54): every deploy that uses this contract
+# produces a tamper-evident audit record (the evidence artifact)
+# regardless of whether the caller wired up its own checks.
+#
+# Standardized outputs (per the issue AC):
+#   commit            — git sha of the deployed change
+#   image_digest      — sha256 digest of the built image
+#   target            — environment / instance the deploy aimed at
+#   actor             — github.actor at deploy time
+#   validation_result — pass | fail | skipped (skipped only when the
+#                       caller passed validate_command='')
+#   rollback_target   — image ref that the deploy displaces (empty
+#                       on first deploy)
+#
+# This workflow does NOT execute the deploy itself — the caller passes
+# the commands. The contract is "you wire up the commands; we enforce
+# the order, the evidence, and the audit shape."
+
+on:
+  workflow_call:
+    inputs:
+      target_environment:
+        description: 'Environment label the deploy aims at (dev | uat | prod)'
+        required: true
+        type: string
+      runner_labels:
+        description: 'Runner label(s) as a JSON array string'
+        required: false
+        type: string
+        default: '["self-hosted", "linux"]'
+      image_name:
+        description: 'Image name (e.g. img-forge). Required for evidence.'
+        required: true
+        type: string
+      image_ref:
+        description: 'Full image ref to be deployed (e.g. ghcr.io/qwickapps/img-forge:1.2.3)'
+        required: true
+        type: string
+      rollback_target:
+        description: 'Image ref to roll back to if validation fails. Empty on first deploy.'
+        required: false
+        type: string
+        default: ''
+      preflight_command:
+        description: 'Preflight check (returns non-zero to abort). Empty defaults to "true".'
+        required: false
+        type: string
+        default: 'true'
+      test_command:
+        description: 'Test command. REQUIRED — empty rejects.'
+        required: true
+        type: string
+      build_command:
+        description: 'Build + publish command. REQUIRED — empty rejects.'
+        required: true
+        type: string
+      deploy_command:
+        description: 'Deploy command. REQUIRED — empty rejects.'
+        required: true
+        type: string
+      validate_command:
+        description: 'Post-deploy validation command. Empty marks validation_result=skipped (allowed for non-prod environments only).'
+        required: false
+        type: string
+        default: ''
+      evidence_extra_json:
+        description: 'Optional JSON object merged into the evidence record under .caller_metadata'
+        required: false
+        type: string
+        default: '{}'
+    outputs:
+      commit:
+        description: 'Git sha of the deployed change'
+        value: ${{ jobs.preflight.outputs.commit }}
+      image_digest:
+        description: 'Sha256 digest of the built image'
+        value: ${{ jobs.build.outputs.image_digest }}
+      target:
+        description: 'Target environment label'
+        value: ${{ jobs.preflight.outputs.target }}
+      actor:
+        description: 'github.actor at deploy time'
+        value: ${{ jobs.preflight.outputs.actor }}
+      validation_result:
+        description: 'pass | fail | skipped'
+        value: ${{ jobs.validate.outputs.result }}
+      rollback_target:
+        description: 'Image ref displaced by this deploy'
+        value: ${{ jobs.preflight.outputs.rollback_target }}
+    secrets:
+      GHCR_PUSH_TOKEN:
+        required: false
+
+jobs:
+  # 1. Preflight — input validation + actor/commit capture
+  preflight:
+    name: Preflight
+    runs-on: ${{ fromJson(inputs.runner_labels) }}
+    outputs:
+      commit:           ${{ steps.snapshot.outputs.commit }}
+      target:           ${{ steps.snapshot.outputs.target }}
+      actor:            ${{ steps.snapshot.outputs.actor }}
+      rollback_target:  ${{ steps.snapshot.outputs.rollback_target }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Validate required inputs
+        run: |
+          # Required commands MUST be non-empty. Empty values defeat
+          # the contract — they would let a caller disable a gate by
+          # passing "". Reject explicitly.
+          if [ -z "${{ inputs.test_command }}" ]; then
+            echo "::error::test_command is required and must not be empty"
+            exit 2
+          fi
+          if [ -z "${{ inputs.build_command }}" ]; then
+            echo "::error::build_command is required and must not be empty"
+            exit 2
+          fi
+          if [ -z "${{ inputs.deploy_command }}" ]; then
+            echo "::error::deploy_command is required and must not be empty"
+            exit 2
+          fi
+
+          # Production deploys must validate post-deploy. Skipping
+          # validation in prod would defeat the AC ("validation
+          # cannot be skipped").
+          if [ "${{ inputs.target_environment }}" = "prod" ] && [ -z "${{ inputs.validate_command }}" ]; then
+            echo "::error::validate_command is required for target_environment=prod"
+            exit 2
+          fi
+
+      - name: Snapshot deploy context
+        id: snapshot
+        run: |
+          {
+            echo "commit=${{ github.sha }}"
+            echo "target=${{ inputs.target_environment }}"
+            echo "actor=${{ github.actor }}"
+            echo "rollback_target=${{ inputs.rollback_target }}"
+          } >> "$GITHUB_OUTPUT"
+
+      - name: Run preflight command
+        run: |
+          set -e
+          ${{ inputs.preflight_command }}
+
+  # 2. Tests — the only "skip" path is "tests pass". A failing test
+  # halts the chain because deploy `needs: tests`.
+  tests:
+    name: Tests
+    needs: preflight
+    runs-on: ${{ fromJson(inputs.runner_labels) }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Run test command
+        run: |
+          set -e
+          ${{ inputs.test_command }}
+
+  # 3. Build + publish — produces the image_digest output downstream
+  # jobs (deploy + evidence) need.
+  build:
+    name: Build + Publish
+    needs: tests
+    runs-on: ${{ fromJson(inputs.runner_labels) }}
+    outputs:
+      image_digest: ${{ steps.digest.outputs.digest }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Run build command
+        run: |
+          set -e
+          ${{ inputs.build_command }}
+
+      - name: Capture image digest
+        id: digest
+        run: |
+          # The caller's build_command is expected to either:
+          #   (a) push the image and write its digest to
+          #       $GITHUB_ENV as IMAGE_DIGEST, OR
+          #   (b) write the digest to ./image-digest.txt
+          # We accept either so the caller's existing build pipelines
+          # don't need to change shape to adopt this contract.
+          digest=""
+          if [ -n "${IMAGE_DIGEST:-}" ]; then
+            digest="$IMAGE_DIGEST"
+          elif [ -f ./image-digest.txt ]; then
+            digest="$(tr -d '[:space:]' < ./image-digest.txt)"
+          fi
+          if [ -z "$digest" ]; then
+            echo "::warning::no image digest captured; the evidence record will record the image_ref instead"
+          fi
+          echo "digest=$digest" >> "$GITHUB_OUTPUT"
+
+  # 4. Deploy — runs the caller's deploy command against the build's
+  # image. Evidence captures the rollback_target BEFORE this runs.
+  deploy:
+    name: Deploy
+    needs: build
+    runs-on: ${{ fromJson(inputs.runner_labels) }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Run deploy command
+        env:
+          IMAGE_REF: ${{ inputs.image_ref }}
+          TARGET_ENV: ${{ inputs.target_environment }}
+          IMAGE_DIGEST: ${{ needs.build.outputs.image_digest }}
+        run: |
+          set -e
+          ${{ inputs.deploy_command }}
+
+  # 5. Validate — post-deploy health/contract check. Empty for non-prod
+  # marks validation_result=skipped; prod requires non-empty per
+  # preflight.
+  validate:
+    name: Validate
+    needs: deploy
+    runs-on: ${{ fromJson(inputs.runner_labels) }}
+    outputs:
+      result: ${{ steps.run.outputs.result }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Run validate command
+        id: run
+        env:
+          IMAGE_REF: ${{ inputs.image_ref }}
+          TARGET_ENV: ${{ inputs.target_environment }}
+        run: |
+          if [ -z "${{ inputs.validate_command }}" ]; then
+            echo "::notice::validate_command empty; marking validation_result=skipped"
+            echo "result=skipped" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          set +e
+          ${{ inputs.validate_command }}
+          rc=$?
+          set -e
+          if [ "$rc" -eq 0 ]; then
+            echo "result=pass" >> "$GITHUB_OUTPUT"
+          else
+            echo "result=fail" >> "$GITHUB_OUTPUT"
+            echo "::error::validate_command failed (rc=$rc); evidence job will mark this deploy as failed"
+            exit "$rc"
+          fi
+
+  # 6. Evidence — emit the rollback evidence JSON + upload as an
+  # artifact. This is the audit record that satisfies the AC. Runs
+  # `if: always()` so a failed validate step still produces evidence
+  # (the evidence carries `validation_result: fail` in that case so
+  # the audit pipeline knows the deploy did not succeed).
+  evidence:
+    name: Emit Evidence
+    needs: [preflight, build, deploy, validate]
+    if: always() && needs.preflight.result == 'success'
+    runs-on: ${{ fromJson(inputs.runner_labels) }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Build evidence record
+        id: emit
+        env:
+          COMMIT:        ${{ needs.preflight.outputs.commit }}
+          TARGET:        ${{ needs.preflight.outputs.target }}
+          ACTOR:         ${{ needs.preflight.outputs.actor }}
+          ROLLBACK_TGT:  ${{ needs.preflight.outputs.rollback_target }}
+          IMAGE_REF:     ${{ inputs.image_ref }}
+          IMAGE_DIGEST:  ${{ needs.build.outputs.image_digest }}
+          DEPLOY_RESULT: ${{ needs.deploy.result }}
+          VALIDATION:    ${{ needs.validate.outputs.result }}
+          EXTRA_JSON:    ${{ inputs.evidence_extra_json }}
+        run: |
+          chmod +x .ci-workflows/scripts/deploy-evidence.sh 2>/dev/null \
+            || chmod +x scripts/deploy-evidence.sh 2>/dev/null \
+            || true
+
+          # Resolve the script path: callers vendor this repo as
+          # .ci-workflows submodule; the script ships at
+          # .ci-workflows/scripts/deploy-evidence.sh. Direct-call
+          # consumers (this repo's own tests) use scripts/...
+          if [ -x .ci-workflows/scripts/deploy-evidence.sh ]; then
+            SCRIPT=".ci-workflows/scripts/deploy-evidence.sh"
+          elif [ -x scripts/deploy-evidence.sh ]; then
+            SCRIPT="scripts/deploy-evidence.sh"
+          else
+            echo "::error::deploy-evidence.sh not found"
+            exit 2
+          fi
+
+          mkdir -p evidence
+          OUT="evidence/deploy-evidence-${{ github.run_id }}.json"
+          "$SCRIPT" \
+            --commit          "$COMMIT" \
+            --target          "$TARGET" \
+            --actor           "$ACTOR" \
+            --image-ref       "$IMAGE_REF" \
+            --image-digest    "$IMAGE_DIGEST" \
+            --rollback-target "$ROLLBACK_TGT" \
+            --deploy-result   "$DEPLOY_RESULT" \
+            --validation      "${VALIDATION:-skipped}" \
+            --extra-json      "$EXTRA_JSON" \
+            > "$OUT"
+
+          # Echo to stdout for the workflow log + summary.
+          jq . "$OUT"
+          echo "path=$OUT" >> "$GITHUB_OUTPUT"
+
+      - name: Upload evidence artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: deploy-evidence-${{ github.run_id }}
+          path: ${{ steps.emit.outputs.path }}
+          retention-days: 90
+          if-no-files-found: error


### PR DESCRIPTION
Closes #6

## Summary
Adds a reusable deploy workflow (`workflows/deploy.yml`) that enforces a strict `needs:` chain — `preflight → tests → build → deploy → validate → evidence` — so reliability gates cannot be bypassed by a caller workflow that rewires jobs. The evidence job runs with `if: always()` so failed deploys still produce an audit artifact. Ships an evidence-emit script, a contract validator, and a 31-test suite covering golden path, mutation rejection, and input validation.

## Files changed
- `workflows/deploy.yml`: 6-job reusable workflow. Required inputs cover the deploy contract (`target_environment`, `image_name`, `image_ref`, `test_command`, `build_command`, `deploy_command`). Outputs: `commit`, `image_digest`, `target`, `actor`, `validation_result`, `rollback_target`. Production validation enforced when `target_environment=prod`.
- `scripts/deploy-evidence.sh`: emits the evidence record as single-line JSON. `--validation` ∈ {pass,fail,skipped}; `--deploy-result` ∈ {success,failure,cancelled,skipped}; `--extra-json` must be a JSON object, merged under `caller_metadata`.
- `scripts/validate-deploy-contract.sh`: PyYAML-based contract validator. Handles YAML 1.1 quirk where `on:` parses as boolean `True`.
- `scripts/tests/contract.test.sh`: 31 tests covering golden path, 11 negative mutations, evidence happy path, optional-field omission, caller_metadata round-trip, and input-validation rejection cases.

## Tests
- `bash scripts/tests/contract.test.sh`: 31 passed, 0 failed.

## Deviations from plan
None.

## Follow-ups (filed separately)
- None — adopters land in subsequent PRs that point their callers at this workflow.