### PR TITLE
[codex] add deploy secrets fetch workflow

### DIFF
--- a/.github/workflows/fetch-secrets.yml
+++ b/.github/workflows/fetch-secrets.yml
@@ -1,0 +1,53 @@
+name: Fetch Deploy Secrets Contract
+
+on:
+  workflow_call:
+    inputs:
+      base_url:
+        description: QwickSecrets base URL.
+        required: false
+        type: string
+        default: https://qwicksecrets.dev.qwickforge.com
+      project:
+        description: QwickApps project name.
+        required: true
+        type: string
+      env:
+        description: QwickApps environment name.
+        required: true
+        type: string
+      keys:
+        description: Comma-separated secret keys to verify.
+        required: false
+        type: string
+        default: TS_AUTHKEY
+      runs_on:
+        description: Runner label(s) as a JSON array string.
+        required: false
+        type: string
+        default: '["self-hosted", "macmini"]'
+    secrets:
+      QWICKSECRETS_DEPLOY_READ_TOKEN:
+        required: true
+
+jobs:
+  fetch:
+    name: Fetch Deploy Secrets
+    runs-on: ${{ fromJson(inputs.runs_on) }}
+    steps:
+      - uses: actions/checkout@v5
+
+      - name: Fetch deploy secrets
+        uses: qwickapps/ci-workflows/actions/fetch-secrets@main
+        with:
+          base-url: ${{ inputs.base_url }}
+          token: ${{ secrets.QWICKSECRETS_DEPLOY_READ_TOKEN }}
+          project: ${{ inputs.project }}
+          env: ${{ inputs.env }}
+          keys: ${{ inputs.keys }}
+          env-file: /tmp/qwicksecrets-fetch-${{ github.run_id }}
+
+      - name: Verify env file was created
+        run: |
+          test -s /tmp/qwicksecrets-fetch-${{ github.run_id }}
+          rm -f /tmp/qwicksecrets-fetch-${{ github.run_id }}

--- a/README.md
+++ b/README.md
@@ -8,8 +8,11 @@ Shared CI workflow scripts for QwickApps repositories. Used as a **git submodule
 
 ```
 ci-workflows/
+├── actions/
+│   └── fetch-secrets/          # Composite action for deploy-time secret injection
 └── scripts/
     ├── attribution-check.sh    # Detects AI co-authorship in PR commits
+    ├── fetch-secrets.sh        # Fetches deploy-allowlisted QwickSecrets values
     └── pr-status-comment.sh    # Posts CI validation results as a PR comment
 ```
 
@@ -148,6 +151,29 @@ export CHECK_OUTPUT="$(./scripts/attribution-check.sh $BASE $HEAD 2>&1)"
     CHECK_STATUS: ${{ steps.attr_check.outputs.status }}
     CHECK_OUTPUT: ${{ steps.attr_check.outputs.output }}
 ```
+
+---
+
+### `actions/fetch-secrets`
+
+Fetches deploy-allowlisted QwickSecrets values into a caller-provided env file.
+The action masks every returned value and writes only `KEY=value` lines to the
+file. It expects the org-level secret `QWICKSECRETS_DEPLOY_READ_TOKEN`.
+
+```yaml
+- name: Fetch Tailscale auth key
+  uses: qwickapps/ci-workflows/actions/fetch-secrets@main
+  with:
+    base-url: https://qwicksecrets.dev.qwickforge.com
+    token: ${{ secrets.QWICKSECRETS_DEPLOY_READ_TOKEN }}
+    project: memories
+    env: prod
+    keys: TS_AUTHKEY
+    env-file: /tmp/app-env-${{ github.run_id }}
+```
+
+The reusable contract workflow at `.github/workflows/fetch-secrets.yml` verifies
+health/auth/key existence without returning secret values across job boundaries.
 
 ---
 

--- a/actions/fetch-secrets/action.yml
+++ b/actions/fetch-secrets/action.yml
@@ -1,0 +1,42 @@
+name: Fetch QwickSecrets Deploy Secrets
+description: Fetch deploy-allowlisted QwickSecrets values into a local env file.
+
+inputs:
+  base-url:
+    description: QwickSecrets base URL.
+    required: false
+    default: https://qwicksecrets.dev.qwickforge.com
+  token:
+    description: Deploy read token from QWICKSECRETS_DEPLOY_READ_TOKEN.
+    required: true
+  project:
+    description: QwickApps project name.
+    required: true
+  env:
+    description: QwickApps environment name.
+    required: true
+  keys:
+    description: Comma-separated secret keys to fetch.
+    required: true
+  env-file:
+    description: Env file to append KEY=value lines to.
+    required: true
+
+outputs:
+  env-file:
+    description: Path to the env file that received fetched secrets.
+    value: ${{ inputs.env-file }}
+
+runs:
+  using: composite
+  steps:
+    - name: Fetch deploy secrets
+      shell: bash
+      run: |
+        "${GITHUB_ACTION_PATH}/../../scripts/fetch-secrets.sh" \
+          --base-url "${{ inputs.base-url }}" \
+          --token "${{ inputs.token }}" \
+          --project "${{ inputs.project }}" \
+          --env "${{ inputs.env }}" \
+          --keys "${{ inputs.keys }}" \
+          --env-file "${{ inputs.env-file }}"

--- a/scripts/fetch-secrets.sh
+++ b/scripts/fetch-secrets.sh
@@ -1,0 +1,118 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+usage() {
+  cat >&2 <<'USAGE'
+Usage: fetch-secrets.sh --base-url URL --token TOKEN --project PROJECT --env ENV --keys KEY[,KEY...] --env-file FILE
+
+Fetches deploy-allowlisted secrets from QwickSecrets and writes KEY=value lines
+to FILE. Secret values are masked for GitHub Actions logs and are never printed.
+USAGE
+}
+
+BASE_URL="${QWICKSECRETS_URL:-}"
+TOKEN="${QWICKSECRETS_DEPLOY_READ_TOKEN:-}"
+PROJECT=""
+ENVIRONMENT=""
+KEYS_CSV=""
+ENV_FILE=""
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --base-url)
+      BASE_URL="${2:-}"
+      shift 2
+      ;;
+    --token)
+      TOKEN="${2:-}"
+      shift 2
+      ;;
+    --project)
+      PROJECT="${2:-}"
+      shift 2
+      ;;
+    --env)
+      ENVIRONMENT="${2:-}"
+      shift 2
+      ;;
+    --keys)
+      KEYS_CSV="${2:-}"
+      shift 2
+      ;;
+    --env-file)
+      ENV_FILE="${2:-}"
+      shift 2
+      ;;
+    -h|--help)
+      usage
+      exit 0
+      ;;
+    *)
+      echo "Unknown argument: $1" >&2
+      usage
+      exit 2
+      ;;
+  esac
+done
+
+if [[ -z "$BASE_URL" || -z "$TOKEN" || -z "$PROJECT" || -z "$ENVIRONMENT" || -z "$KEYS_CSV" || -z "$ENV_FILE" ]]; then
+  usage
+  exit 2
+fi
+
+if ! command -v jq >/dev/null 2>&1; then
+  echo "jq is required to fetch deploy secrets" >&2
+  exit 2
+fi
+
+TMP_RESPONSE="$(mktemp)"
+TMP_BODY="$(mktemp)"
+trap 'rm -f "$TMP_RESPONSE" "$TMP_BODY"' EXIT
+
+jq -n \
+  --arg project "$PROJECT" \
+  --arg env "$ENVIRONMENT" \
+  --arg keys "$KEYS_CSV" \
+  '{project: $project, env: $env, keys: ($keys | split(",") | map(gsub("^\\s+|\\s+$"; "")) | map(select(length > 0)))}' \
+  > "$TMP_BODY"
+
+HTTP_STATUS="$(curl -sS \
+  -o "$TMP_RESPONSE" \
+  -w '%{http_code}' \
+  -X POST \
+  -H "Authorization: Bearer ${TOKEN}" \
+  -H 'Content-Type: application/json' \
+  -H 'Cache-Control: no-store' \
+  --data-binary "@${TMP_BODY}" \
+  "${BASE_URL%/}/v1/deploy/secrets")"
+
+if [[ "$HTTP_STATUS" != "200" ]]; then
+  ERROR_MESSAGE="$(jq -r '.error // empty' "$TMP_RESPONSE" 2>/dev/null || true)"
+  if [[ -n "$ERROR_MESSAGE" ]]; then
+    echo "QwickSecrets deploy fetch failed with HTTP ${HTTP_STATUS}: ${ERROR_MESSAGE}" >&2
+  else
+    echo "QwickSecrets deploy fetch failed with HTTP ${HTTP_STATUS}" >&2
+  fi
+  exit 1
+fi
+
+mkdir -p "$(dirname "$ENV_FILE")"
+touch "$ENV_FILE"
+chmod 600 "$ENV_FILE"
+
+IFS=',' read -r -a REQUESTED_KEYS <<< "$KEYS_CSV"
+for raw_key in "${REQUESTED_KEYS[@]}"; do
+  key="$(printf '%s' "$raw_key" | xargs)"
+  [[ -z "$key" ]] && continue
+
+  value="$(jq -r --arg key "$key" '.secrets[$key].value // empty' "$TMP_RESPONSE")"
+  if [[ -z "$value" ]]; then
+    echo "QwickSecrets response did not include ${key}" >&2
+    exit 1
+  fi
+
+  echo "::add-mask::${value}"
+  printf '%s=%s\n' "$key" "$value" >> "$ENV_FILE"
+done
+
+echo "Fetched deploy secrets for ${PROJECT}/${ENVIRONMENT}: ${KEYS_CSV}"


### PR DESCRIPTION
## Summary

Adds the shared deploy-time secret fetcher for qwickapps/mcp#65.

- adds a composite action that posts to QwickSecrets and appends masked KEY=value lines to a caller-provided env file
- adds .github/workflows/fetch-secrets.yml as the reusable contract workflow
- documents the org-level QWICKSECRETS_DEPLOY_READ_TOKEN pattern

## Validation

- bash -n scripts/fetch-secrets.sh
- test -x scripts/fetch-secrets.sh
- grep checks for workflow_call and required secret contract
- git diff --check

Depends on qwickapps/secrets#41.
Tracking: qwickapps/mcp#65