### PR TITLE
[codex] add create-worktree wrapper

### DIFF
--- a/.claude/scripts/create-worktree.sh
+++ b/.claude/scripts/create-worktree.sh
@@ -1,0 +1,26 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+if [[ $# -lt 1 || $# -gt 2 ]]; then
+  echo "Usage: $0 <branch> [base]" >&2
+  exit 1
+fi
+
+BRANCH="$1"
+BASE="${2:-main}"
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_DIR="$(cd "$SCRIPT_DIR/../.." && pwd)"
+REPO_NAME="$(basename "$REPO_DIR")"
+PARENT_DIR="$(dirname "$REPO_DIR")"
+WORKTREE_DIR="$PARENT_DIR/${REPO_NAME}-wt-${BRANCH//\//-}"
+
+if [[ -e "$WORKTREE_DIR" ]]; then
+  echo "Worktree path already exists: $WORKTREE_DIR" >&2
+  exit 1
+fi
+
+cd "$REPO_DIR"
+git fetch origin "$BASE"
+git worktree add "$WORKTREE_DIR" -b "$BRANCH" "origin/$BASE"
+echo "$WORKTREE_DIR"


### PR DESCRIPTION
## Summary
- Adds `.claude/scripts/create-worktree.sh` as the standard QwickApps git worktree wrapper.
- Uses sibling `repo-wt-branch` worktree paths, defaults the base branch to `main`, and fetches `origin/<base>` before creating the branch.

Refs qwickapps/protocols#37.

## Validation
- `bash -n .claude/scripts/create-worktree.sh`
- `git diff --cached --check` before commit
- Build/unit tests not run; this is a shell helper-only change.