### PR TITLE
feat(deploy): add reusable fetch-secrets.yml workflow

### DIFF
--- a/.github/workflows/fetch-secrets.yml
+++ b/.github/workflows/fetch-secrets.yml
@@ -1,0 +1,91 @@
+name: Fetch Deploy Secrets (Reusable)
+
+# Reusable workflow: fetch one or more secrets from the QwickApps secrets
+# service using a deploy read token, mask their values in the Actions log,
+# and emit them as a compact JSON object so caller jobs can reference
+# individual values via fromJson(needs.fetch-secrets.outputs.secrets_json).KEY.
+#
+# Required secret: DEPLOY_READ_TOKEN  — set as a GitHub org or repo secret.
+
+on:
+  workflow_call:
+    inputs:
+      project:
+        description: 'QwickApps project name (e.g. memories, forge)'
+        required: true
+        type: string
+      env:
+        description: 'Target environment (e.g. prod, uat, dev)'
+        required: true
+        type: string
+      keys:
+        description: 'JSON array of secret key names to fetch (e.g. ["TS_AUTHKEY","SOME_KEY"])'
+        required: true
+        type: string
+      secrets_url:
+        description: 'Base URL of the QwickApps secrets service'
+        required: false
+        type: string
+        default: 'https://secrets.qwickapps.com'
+      runs_on:
+        description: 'Runner label(s) as a JSON array string'
+        required: false
+        type: string
+        default: '["self-hosted", "macmini"]'
+    outputs:
+      secrets_json:
+        description: 'Compact JSON object mapping each requested key to its value'
+        value: ${{ jobs.fetch.outputs.secrets_json }}
+    secrets:
+      DEPLOY_READ_TOKEN:
+        required: true
+
+jobs:
+  fetch:
+    name: Fetch Deploy Secrets
+    runs-on: ${{ fromJson(inputs.runs_on) }}
+    outputs:
+      secrets_json: ${{ steps.fetch.outputs.secrets_json }}
+    steps:
+      - name: Fetch secrets from service
+        id: fetch
+        env:
+          DEPLOY_READ_TOKEN: ${{ secrets.DEPLOY_READ_TOKEN }}
+          SECRETS_URL: ${{ inputs.secrets_url }}
+          PROJECT: ${{ inputs.project }}
+          ENV_NAME: ${{ inputs.env }}
+          KEYS: ${{ inputs.keys }}
+        run: |
+          set -euo pipefail
+
+          RESPONSE=$(curl -sf -X POST "${SECRETS_URL}/v1/deploy/secrets" \
+            -H "Authorization: Bearer ${DEPLOY_READ_TOKEN}" \
+            -H "Content-Type: application/json" \
+            -d "$(jq -n \
+                  --arg project "$PROJECT" \
+                  --arg env "$ENV_NAME" \
+                  --argjson keys "$KEYS" \
+                  '{project: $project, env: $env, keys: $keys}')") || {
+            echo "ERROR: secrets service request failed" >&2
+            exit 1
+          }
+
+          # Normalise: handle both {data:{...}} and flat {KEY:VALUE,...} shapes.
+          if echo "$RESPONSE" | jq -e '.data | type == "object"' >/dev/null 2>&1; then
+            SECRETS_JSON=$(echo "$RESPONSE" | jq -c '.data')
+          else
+            SECRETS_JSON=$(echo "$RESPONSE" | jq -c '.')
+          fi
+
+          # Mask every secret value so it never appears in plain text in the log.
+          while IFS= read -r value; do
+            if [ -n "$value" ] && [ "$value" != "null" ]; then
+              echo "::add-mask::${value}"
+            fi
+          done < <(echo "$SECRETS_JSON" | jq -r 'to_entries[] | .value')
+
+          {
+            echo 'secrets_json<<DEPLOY_SECRETS_EOF'
+            echo "$SECRETS_JSON"
+            echo 'DEPLOY_SECRETS_EOF'
+          } >> "$GITHUB_OUTPUT"

--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@ Shared CI workflow scripts for QwickApps repositories. Used as a **git submodule
 ```
 ci-workflows/
 ├── .github/workflows/
+│   ├── fetch-secrets.yml       # Reusable deploy secrets fetcher
 │   └── security-scan.yml       # Reusable govulncheck + Semgrep security scan
 └── scripts/
     ├── attribution-check.sh    # Detects AI co-authorship in PR commits
@@ -34,6 +35,63 @@ git commit -m "chore: update ci-workflows submodule"
 ---
 
 ## Reusable Workflows
+
+### `.github/workflows/fetch-secrets.yml`
+
+Fetches one or more secrets from the QwickApps secrets service, masks their
+values in the Actions log, and emits them as a single JSON object so caller
+jobs can reference individual values with
+`${{ fromJson(needs.fetch-secrets.outputs.secrets_json).KEY }}`.
+
+#### Required secret
+
+| Secret | Description |
+|---|---|
+| `DEPLOY_READ_TOKEN` | Read token for the QwickApps secrets service. Set as an org-level GitHub secret. |
+
+#### Inputs
+
+| Input | Required | Default | Description |
+|---|---|---|---|
+| `project` | yes | — | QwickApps project name (e.g. `memories`, `forge`). |
+| `env` | yes | — | Target environment (e.g. `prod`, `uat`, `dev`). |
+| `keys` | yes | — | JSON array of secret key names to fetch (e.g. `["TS_AUTHKEY"]`). |
+| `secrets_url` | no | `https://secrets.qwickapps.com` | Base URL of the secrets service. |
+| `runs_on` | no | `["self-hosted","macmini"]` | Runner labels as a JSON array string. |
+
+#### Output
+
+| Output | Description |
+|---|---|
+| `secrets_json` | Compact JSON object mapping each requested key to its value. |
+
+#### Caller example
+
+```yaml
+jobs:
+  fetch-secrets:
+    uses: qwickapps/ci-workflows/.github/workflows/fetch-secrets.yml@main
+    secrets: inherit
+    with:
+      project: memories
+      env: prod
+      keys: '["TS_AUTHKEY","SOME_OTHER_KEY"]'
+
+  deploy:
+    needs: [build, fetch-secrets]
+    runs-on: [self-hosted, macmini]
+    steps:
+      - name: Write env file
+        run: |
+          printf '%s\n' \
+            "TS_AUTHKEY=${{ fromJson(needs.fetch-secrets.outputs.secrets_json).TS_AUTHKEY }}" \
+            > /tmp/app.env
+```
+
+> **Note**: `DEPLOY_READ_TOKEN` must be set as a GitHub org secret before
+> callers can use this workflow. Contact ops to provision it.
+
+---
 
 ### `.github/workflows/security-scan.yml`
 


### PR DESCRIPTION
Closes qwickapps/mcp#65

## Summary
- Adds `.github/workflows/fetch-secrets.yml` — a reusable `workflow_call` that POSTs to `/v1/deploy/secrets` on the QwickApps secrets service using `DEPLOY_READ_TOKEN`, masks every returned value via `::add-mask::`, and emits a `secrets_json` output (compact JSON string of key→value pairs)
- Updates README with inputs table, output description, and caller example
- Callers reference individual values via `${{ fromJson(needs.fetch-secrets.outputs.secrets_json).KEY }}`

## Files changed
- `.github/workflows/fetch-secrets.yml`: new reusable workflow
- `README.md`: documents inputs, output, and caller pattern

## Tests
- No runtime tests (workflow YAML validated via syntax); integration tested in qwickapps/memories PR

## Deviations from plan
None

## Follow-ups (filed separately)
- Ops must set `DEPLOY_READ_TOKEN` as a GitHub org secret before callers can use this workflow