### PR TITLE
fix(deploy): revert build job permissions block that breaks reusable workflow callers

### DIFF
--- a/.github/workflows/deploy-app.yml
+++ b/.github/workflows/deploy-app.yml
@@ -237,11 +237,9 @@ jobs:
     needs: prepare
     if: inputs.image_ref == ''
     runs-on: [self-hosted, macmini]
-    permissions:
-      contents: read
-      packages: write
-    # GHCR push uses GHCR_PUSH_TOKEN PAT when available; falls back to GITHUB_TOKEN
-    # with explicit packages:write (overrides org read-only default for this job).
+    # GHCR push uses GHCR_PUSH_TOKEN PAT (see 'Login to GHCR' step) - we don't
+    # need elevated GITHUB_TOKEN packages:write, which the qwickapps org policy
+    # disables at the workflow-defaults level.
     steps:
       - name: Checkout code
         uses: actions/checkout@v4


### PR DESCRIPTION
## Root cause

Commit 7567d43 added `permissions: packages: write` to the `build` job inside `deploy-app.yml`. This breaks every repo that calls the reusable workflow.

**Why**: GitHub Actions **startup_failure** occurs when a reusable workflow requests permissions that the calling workflow's GITHUB_TOKEN can't be granted (e.g., due to org policy). Adding `permissions:` at the job level in a reusable workflow propagates this requirement to callers.

## Impact

Every repo calling `deploy-app.yml@main` via `uses:` without a top-level `permissions: packages: write` in their own workflow file gets `startup_failure` — no jobs run. Confirmed broken: `qwickapps/mcp` since 2026-05-17 (7 consecutive startup_failures across all pushes to main).

## Fix

Revert the `permissions:` block from the build job. Restore the original comment explaining why it's intentionally absent:

> "GHCR push uses GHCR_PUSH_TOKEN PAT (see 'Login to GHCR' step) - we don't need elevated GITHUB_TOKEN packages:write, which the qwickapps org policy disables at the workflow-defaults level."

`GHCR_PUSH_TOKEN` is listed as a required secret for callers of this workflow. Repos that set it use the PAT for GHCR pushes and don't need GITHUB_TOKEN `packages:write` at all.

## Companion PR

`qwickapps/mcp#133` adds `permissions: packages: write` at the mcp deploy.yml workflow level as belt-and-suspenders, in case other callers also need it.