### PR TITLE
feat(deploy): deploy-preflight reusable workflow + wire into deploy-app (protocols#261)

### DIFF
--- a/.github/workflows/deploy-app.yml
+++ b/.github/workflows/deploy-app.yml
@@ -133,8 +133,14 @@ env:
   OWNER: qwickapps
 
 jobs:
-  # -- Phase 0: Compute metadata ------------------------------------------------
+  # -- Phase 0a: Deploy contract preflight --------------------------------------
+  preflight:
+    uses: qwickapps/ci-workflows/.github/workflows/deploy-preflight.yml@main
+    secrets: inherit
+
+  # -- Phase 0b: Compute metadata -----------------------------------------------
   prepare:
+    needs: [preflight]
     runs-on: [self-hosted, macmini]
     outputs:
       image_ref:        ${{ steps.meta.outputs.image_ref }}

--- a/.github/workflows/deploy-preflight.yml
+++ b/.github/workflows/deploy-preflight.yml
@@ -1,0 +1,34 @@
+name: Deploy Preflight
+
+# Reusable workflow: validates deploy.contract.yml in the caller repo before
+# any build or deploy work begins. Checks Dockerfile existence, node version
+# consistency, package manager alignment, health_path format, and workflow
+# YAML validity. Fails fast with descriptive messages if the contract is
+# absent or unparseable; accumulates all other failures before exit.
+#
+# Canonical contract: qwickapps/protocols#261.
+
+on:
+  workflow_call:
+
+jobs:
+  preflight:
+    runs-on: [self-hosted, macmini]
+    steps:
+      - name: Checkout caller repo
+        uses: actions/checkout@v4
+
+      - name: Checkout protocols scripts
+        uses: actions/checkout@v4
+        with:
+          repository: qwickapps/protocols
+          path: .protocols
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Install PyYAML
+        run: python3 -m pip install --user PyYAML --quiet 2>/dev/null || true
+
+      - name: Run deploy contract preflight
+        run: |
+          chmod +x .protocols/scripts/preflight-deploy-contract.sh
+          .protocols/scripts/preflight-deploy-contract.sh


### PR DESCRIPTION
## Summary

- Adds `.github/workflows/deploy-preflight.yml` — reusable workflow that checks out the caller repo + protocols, installs PyYAML, and runs `preflight-deploy-contract.sh`
- Modifies `.github/workflows/deploy-app.yml` — adds `preflight` job as Phase 0a; `prepare` now has `needs: [preflight]` so the validation gate cannot be skipped

## What the preflight validates

1. `deploy.contract.yml` exists and is valid YAML
2. Dockerfile declared in contract exists
3. `package.json` exists for node apps (when not `dockerfile_only`)
4. Node version consistency across `.nvmrc`, `package.json engines.node`, and contract
5. Package manager consistency across `package.json packageManager` and contract
6. `health_path` starts with `/`
7. All `.github/workflows/*.yml` files are valid YAML

## Test plan

- [x] Both workflow YAML files validate with `python3 -c "import yaml; yaml.safe_load(...)"`
- [x] Companion protocols PR #265 has 10 BATS tests passing for the preflight script
- [x] `preflight` job is first in job order; `prepare` correctly lists `needs: [preflight]`

## Related

- Part of qwickapps/protocols#261
- Companion protocols PR: qwickapps/protocols#265