### PR TITLE
fix(deploy-preflight): checkout private protocols via runner creds, not GITHUB_TOKEN (#31)

### DIFF
--- a/.github/workflows/deploy-preflight.yml
+++ b/.github/workflows/deploy-preflight.yml
@@ -22,8 +22,8 @@ jobs:
         uses: actions/checkout@v4
         with:
           repository: qwickapps/protocols
+          ref: main
           path: .protocols
-          token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Install PyYAML
         run: python3 -m pip install --user PyYAML --quiet 2>/dev/null || true


### PR DESCRIPTION
Closes #31

Removes the caller-scoped GITHUB_TOKEN from the private protocols checkout.
Pins the checkout to main to match the working promote-to-live workflow.