### PR TITLE
fix(deploy-preflight): clone protocols via runner git creds (actions/checkout token cannot read private repo) (#31)

### DIFF
--- a/.github/workflows/deploy-preflight.yml
+++ b/.github/workflows/deploy-preflight.yml
@@ -19,11 +19,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Checkout protocols scripts
-        uses: actions/checkout@v4
-        with:
-          repository: qwickapps/protocols
-          ref: main
-          path: .protocols
+        run: git clone --depth 1 https://github.com/qwickapps/protocols .protocols
 
       - name: Install PyYAML
         run: python3 -m pip install --user PyYAML --quiet 2>/dev/null || true


### PR DESCRIPTION
Closes #31. Supersedes #32 which was insufficient.