### PR TITLE
feat(deploy): block placeholder/garbage/format-invalid env values before deploy (#36)

### DIFF
--- a/.github/workflows/deploy-app.yml
+++ b/.github/workflows/deploy-app.yml
@@ -238,9 +238,45 @@ jobs:
           echo "gateway_app_name=${GATEWAY_APP_NAME}" >> "$GITHUB_OUTPUT"
           echo "live_app_url=${LIVE_APP_URL}"         >> "$GITHUB_OUTPUT"
 
+  # -- Phase 0c: Validate rendered env values (qwickapps/ci-workflows#36) --------
+  # BLOCKING gate. The caller's write-env-file job renders the deploy env to
+  # /tmp/app-env-<env>-<app>.env BEFORE this reusable workflow runs. We reject
+  # empty / placeholder / format-invalid values (e.g. TS_EPHEMERAL_AUTHKEY=`-`)
+  # here, before any build or CapRover provisioning happens, so a garbage secret
+  # cannot reach `tailscale up --authkey=-` and crash-loop the container.
+  # Both `build` and the provision jobs depend on this job, so neither the
+  # normal build path nor the prebuilt-image (image_ref) path can skip it.
+  validate-env:
+    needs: [prepare]
+    runs-on: [self-hosted, macmini]
+    steps:
+      - name: Checkout ci-workflows scripts
+        uses: actions/checkout@v4
+        with:
+          repository: qwickapps/ci-workflows
+          ref: main
+          path: .ci-workflows
+          sparse-checkout: |
+            scripts
+          sparse-checkout-cone-mode: false
+
+      - name: Make scripts executable
+        run: chmod +x .ci-workflows/scripts/*.sh
+
+      - name: Validate rendered env values
+        run: |
+          ENV="${{ inputs.environment }}"
+          APP="${{ inputs.app_name }}"
+          ENV_FILE="/tmp/app-env-${ENV}-${APP}.env"
+          if [ ! -f "$ENV_FILE" ]; then
+            echo "::error::Rendered env file not found: ${ENV_FILE}. The caller's write-env-file job must render the deploy env before deploy-app.yml runs."
+            exit 1
+          fi
+          .ci-workflows/scripts/validate-env-values.sh "$ENV_FILE"
+
   # -- Phase 1: Build & push Docker image ---------------------------------------
   build:
-    needs: prepare
+    needs: [prepare, validate-env]
     if: inputs.image_ref == ''
     runs-on: [self-hosted, macmini]
     # GHCR push uses GHCR_PUSH_TOKEN PAT (see 'Login to GHCR' step) - we don't
@@ -328,10 +364,11 @@ jobs:
   # SOPS decrypt step in deploy-faabzi.yml. If no env file is present the job
   # skips env update and just ensures the app exists.
   provision-app:
-    needs: [prepare, build]
+    needs: [prepare, validate-env, build]
     if: |
       always() &&
       needs.prepare.result == 'success' &&
+      needs.validate-env.result == 'success' &&
       (needs.build.result == 'success' || needs.build.result == 'skipped')
     runs-on: [self-hosted, macmini]
     concurrency:
@@ -424,10 +461,11 @@ jobs:
 
   # -- Phase 1.5 (parallel with build): Provision gateway route -----------------
   provision-gateway:
-    needs: [prepare, build]
+    needs: [prepare, validate-env, build]
     if: |
       always() &&
       needs.prepare.result == 'success' &&
+      needs.validate-env.result == 'success' &&
       (needs.build.result == 'success' || needs.build.result == 'skipped')
     runs-on: [self-hosted, macmini]
     continue-on-error: true

--- a/.github/workflows/deploy-app.yml
+++ b/.github/workflows/deploy-app.yml
@@ -269,8 +269,12 @@ jobs:
           APP="${{ inputs.app_name }}"
           ENV_FILE="/tmp/app-env-${ENV}-${APP}.env"
           if [ ! -f "$ENV_FILE" ]; then
-            echo "::error::Rendered env file not found: ${ENV_FILE}. The caller's write-env-file job must render the deploy env before deploy-app.yml runs."
-            exit 1
+            # Some callers render env via an alternate mechanism (e.g. SOPS in
+            # deploy-faabzi.yml) and do not produce this file; provision-app
+            # tolerates that, so we must not block them here. SOPS-path value
+            # validation is tracked as a follow-up on #36.
+            echo "::notice::No rendered env file at ${ENV_FILE}; caller uses an alternate env mechanism — skipping rendered-env value validation."
+            exit 0
           fi
           .ci-workflows/scripts/validate-env-values.sh "$ENV_FILE"
 

--- a/scripts/tests/validate-env-values.test.sh
+++ b/scripts/tests/validate-env-values.test.sh
@@ -1,0 +1,112 @@
+#!/usr/bin/env bash
+#
+# Unit tests for scripts/validate-env-values.sh (qwickapps/ci-workflows#36).
+#
+# Covers the loophole that crash-looped the MCP server: a placeholder value
+# (`-`) passing a naive non-empty check. Asserts the validator accepts a
+# fully-valid env file and rejects empty, placeholder, and format-invalid
+# values (auth keys, URLs, short service keys).
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+SCRIPTS_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
+VALIDATOR="$SCRIPTS_DIR/validate-env-values.sh"
+
+TMPDIR_TEST="$(mktemp -d)"
+trap 'rm -rf "$TMPDIR_TEST"' EXIT
+
+pass=0
+fail=0
+
+# assert_pass <desc> <env-file-contents>
+assert_pass() {
+  local desc="$1"
+  local body="$2"
+  local f="$TMPDIR_TEST/env"
+  printf '%s\n' "$body" > "$f"
+  if bash "$VALIDATOR" "$f" >/dev/null 2>&1; then
+    echo "  PASS: $desc"
+    pass=$((pass + 1))
+  else
+    echo "  FAIL: $desc (validator rejected a file it should have accepted)"
+    bash "$VALIDATOR" "$f" || true
+    fail=$((fail + 1))
+  fi
+}
+
+# assert_fail <desc> <env-file-contents>
+assert_fail() {
+  local desc="$1"
+  local body="$2"
+  local f="$TMPDIR_TEST/env"
+  printf '%s\n' "$body" > "$f"
+  if bash "$VALIDATOR" "$f" >/dev/null 2>&1; then
+    echo "  FAIL: $desc (validator accepted a file it should have rejected)"
+    fail=$((fail + 1))
+  else
+    echo "  PASS: $desc"
+    pass=$((pass + 1))
+  fi
+}
+
+# A fully-valid env file used as the golden baseline. Each typed key is
+# well-formed: auth keys carry the tskey- prefix, the API key carries
+# tskey-api-, URLs are http(s), and the service/api keys are >= 16 chars.
+VALID_ENV="$(cat <<'EOF'
+# qwickapps deploy env (golden)
+NODE_ENV=production
+TS_EPHEMERAL_AUTHKEY=tskey-auth-abc123def456ghi789
+TS_API_KEY=tskey-api-xyz987uvw654rst321
+SECRETS_SERVICE_URL=https://secrets.qwickforge.com
+SECRETS_SERVICE_KEY=super-long-secret-key-1234567890
+DATABASE_CONNECTION=postgres://user:pass@host:5432/db?sslmode=require
+SOME_API_KEY=0123456789abcdef0123
+# trailing comment and blank line below
+
+GREETING=hello=world
+EOF
+)"
+
+echo "== validate-env-values: golden path =="
+assert_pass "fully-valid env file passes" "$VALID_ENV"
+
+echo "== validate-env-values: empty / placeholder rejection =="
+assert_fail "literal dash placeholder rejected" \
+  "TS_EPHEMERAL_AUTHKEY=-"
+assert_fail "empty value rejected" \
+  "FOO="
+assert_fail "whitespace-only value rejected" \
+  "FOO=   "
+assert_fail "'changeme' placeholder rejected" \
+  "ADMIN_PASSWORD=changeme"
+assert_fail "case-insensitive placeholder rejected" \
+  "ADMIN_PASSWORD=ChangeMe"
+assert_fail "placeholder regex (replace...) rejected" \
+  "API_TOKEN=replace-with-real-token"
+assert_fail "placeholder regex (...-here) rejected" \
+  "API_TOKEN=put-the-token-here"
+
+echo "== validate-env-values: typed-key format rejection =="
+assert_fail "TS authkey not starting tskey- rejected" \
+  "TS_EPHEMERAL_AUTHKEY=not-a-tailscale-key-value"
+assert_fail "TS_API_KEY not starting tskey-api- rejected" \
+  "TS_API_KEY=tskey-auth-wrong-prefix-1234567890"
+assert_fail "_URL not starting http rejected" \
+  "SECRETS_SERVICE_URL=secrets.qwickforge.com"
+assert_fail "short _SERVICE_KEY rejected" \
+  "SECRETS_SERVICE_KEY=short"
+assert_fail "short _API_KEY rejected" \
+  "SOME_API_KEY=tooshort"
+
+echo "== validate-env-values: well-formed typed keys pass =="
+assert_pass "TS_API_KEY with tskey-api- prefix passes" \
+  "TS_API_KEY=tskey-api-1234567890abcdef"
+assert_pass "comment + blank lines only passes (no values)" \
+  "# only a comment"
+assert_pass "value containing = passes" \
+  "GREETING=key=value=pairs"
+
+echo ""
+echo "Tests: $pass passed, $fail failed"
+[ "$fail" -eq 0 ]

--- a/scripts/validate-env-values.sh
+++ b/scripts/validate-env-values.sh
@@ -1,0 +1,194 @@
+#!/usr/bin/env bash
+#
+# validate-env-values.sh — reject placeholder, garbage, or format-invalid
+# environment-variable values before any build or deploy work begins.
+#
+# Closes qwickapps/ci-workflows#36. The MCP server crash-looped for ~30h
+# because the GitHub secret TS_EPHEMERAL_AUTHKEY had been set to the literal
+# value `-` to satisfy a naive "non-empty" check. The container then ran
+# `tailscale up --authkey=-`, which fails, so the container exited and 502'd.
+# A non-empty check is not enough: we must reject known placeholder tokens
+# and assert a real format for typed keys (auth keys, URLs, API/service keys).
+#
+# Usage:
+#   validate-env-values.sh <path/to/app-env-<env>-<app>.env>
+#
+# The env file is KEY=VALUE per line. Blank lines and `#` comments are
+# skipped. Values may themselves contain `=` (we split on the first one).
+#
+# Exits 1 (printing every offending KEY with the reason) if ANY value is:
+#   - empty or whitespace-only;
+#   - a known placeholder (case-insensitive exact match) or matches a
+#     placeholder regex;
+#   - format-invalid for a typed key.
+# On success prints `validate-env-values: all N values valid`.
+
+set -euo pipefail
+
+usage() {
+  cat <<'EOF'
+Usage:
+  validate-env-values.sh <env-file>
+
+Validates that every KEY=VALUE in <env-file> carries a real value:
+non-empty, not a known placeholder, and well-formed for typed keys
+(*AUTHKEY*/TS_*KEY auth keys, *_URL URLs, *_API_KEY / *_SERVICE_KEY keys).
+
+Exits non-zero and prints every offending key with a reason on failure.
+EOF
+}
+
+if [ "${1:-}" = "--help" ] || [ "${1:-}" = "-h" ]; then
+  usage
+  exit 0
+fi
+
+ENV_FILE="${1:-}"
+if [ -z "$ENV_FILE" ]; then
+  echo "::error::validate-env-values: missing env-file argument" >&2
+  usage >&2
+  exit 2
+fi
+if [ ! -f "$ENV_FILE" ]; then
+  echo "::error::validate-env-values: env file not found: $ENV_FILE" >&2
+  exit 2
+fi
+
+# Known placeholder tokens. Matched case-insensitively against the whole
+# (trimmed) value. These are values an operator might type to satisfy a
+# naive non-empty check without supplying a real secret.
+PLACEHOLDERS=(
+  "-"
+  "changeme"
+  "change-me"
+  "set-the-correct-value"
+  "todo"
+  "tbd"
+  "xxx"
+  "none"
+  "null"
+  "placeholder"
+  "your-key-here"
+)
+
+# Trim leading/trailing whitespace from a value.
+trim() {
+  local s="$1"
+  # Strip leading whitespace.
+  s="${s#"${s%%[![:space:]]*}"}"
+  # Strip trailing whitespace.
+  s="${s%"${s##*[![:space:]]}"}"
+  printf '%s' "$s"
+}
+
+failed=0
+count=0
+
+report() {
+  # report <key> <reason>
+  failed=1
+  echo "::error::validate-env-values: ${1}: ${2}"
+}
+
+# Lowercase helper that is safe on bash 3.2 (macOS self-hosted runner ships
+# bash 3.2, which lacks the ${var,,} expansion).
+lower() {
+  printf '%s' "$1" | tr '[:upper:]' '[:lower:]'
+}
+
+while IFS= read -r line || [ -n "$line" ]; do
+  # Skip blank / whitespace-only lines.
+  trimmed_line="$(trim "$line")"
+  [ -n "$trimmed_line" ] || continue
+  # Skip comments.
+  case "$trimmed_line" in
+    \#*) continue ;;
+  esac
+  # Require a KEY=VALUE shape.
+  case "$line" in
+    *=*) ;;
+    *)
+      report "$trimmed_line" "not a KEY=VALUE line"
+      continue
+      ;;
+  esac
+
+  # Split on the FIRST `=` only; the value may contain further `=`.
+  key="${line%%=*}"
+  value="${line#*=}"
+  key="$(trim "$key")"
+  value_trimmed="$(trim "$value")"
+
+  [ -n "$key" ] || { report "<blank>" "empty key"; continue; }
+
+  count=$((count + 1))
+
+  # 1. Empty / whitespace-only value.
+  if [ -z "$value_trimmed" ]; then
+    report "$key" "value is empty or whitespace-only"
+    continue
+  fi
+
+  # 2. Known placeholder tokens (case-insensitive exact match).
+  value_lc="$(lower "$value_trimmed")"
+  is_placeholder=0
+  for ph in "${PLACEHOLDERS[@]}"; do
+    if [ "$value_lc" = "$(lower "$ph")" ]; then
+      report "$key" "value is a known placeholder ('${value_trimmed}')"
+      is_placeholder=1
+      break
+    fi
+  done
+  [ "$is_placeholder" -eq 0 ] || continue
+
+  # 2b. Placeholder regexes: ^your-.*-here$, ^replace.*, .*-here$ (on lowercased).
+  if [[ "$value_lc" =~ ^your-.*-here$ ]] \
+    || [[ "$value_lc" =~ ^replace.* ]] \
+    || [[ "$value_lc" =~ .*-here$ ]]; then
+    report "$key" "value matches a placeholder pattern ('${value_trimmed}')"
+    continue
+  fi
+
+  # 3. Format checks for typed keys. The value used for format checks is the
+  # trimmed value (callers should not store leading/trailing whitespace).
+  key_uc="$(printf '%s' "$key" | tr '[:lower:]' '[:upper:]')"
+
+  # 3a. Tailscale-style auth keys.
+  #   - TS_API_KEY must start with `tskey-api-`.
+  #   - Any other *AUTHKEY* or TS_*KEY must start with `tskey-`.
+  if [ "$key_uc" = "TS_API_KEY" ]; then
+    case "$value_trimmed" in
+      tskey-api-*) ;;
+      *) report "$key" "Tailscale API key must start with 'tskey-api-'" ; continue ;;
+    esac
+  elif [[ "$key_uc" == *AUTHKEY* ]] || [[ "$key_uc" == TS_*KEY ]]; then
+    case "$value_trimmed" in
+      tskey-*) ;;
+      *) report "$key" "Tailscale auth key must start with 'tskey-'" ; continue ;;
+    esac
+  fi
+
+  # 3b. URLs must start with http:// or https://.
+  if [[ "$key_uc" == *_URL ]]; then
+    case "$value_trimmed" in
+      http://*|https://*) ;;
+      *) report "$key" "URL must start with http:// or https://" ; continue ;;
+    esac
+  fi
+
+  # 3c. API / service keys (that are not URLs) must be at least 16 chars.
+  if [[ "$key_uc" != *_URL ]] \
+    && { [[ "$key_uc" == *_SERVICE_KEY ]] || [[ "$key_uc" == *_API_KEY ]]; }; then
+    if [ "${#value_trimmed}" -lt 16 ]; then
+      report "$key" "secret/API key must be at least 16 characters (got ${#value_trimmed})"
+      continue
+    fi
+  fi
+done < "$ENV_FILE"
+
+if [ "$failed" -ne 0 ]; then
+  echo "::error::validate-env-values: one or more values are invalid — see errors above; refusing to deploy" >&2
+  exit 1
+fi
+
+echo "validate-env-values: all ${count} values valid"


### PR DESCRIPTION
Closes #36 (RC1). Part of #25 / #24.

## What
Adds a **blocking, fleet-wide** pre-deploy gate that rejects bad env values before any build or CapRover provisioning.

- `scripts/validate-env-values.sh` — validates the rendered `/tmp/app-env-<env>-<app>.env`; fails (listing every offending key) on:
  - empty / whitespace-only values;
  - known placeholders (`-`, `changeme`, `set-the-correct-value`, `todo`, `xxx`, `none`, `null`, `placeholder`, `your-key-here`, …) + regexes (`^your-.*-here$`, `^replace.*`, `.*-here$`);
  - format-invalid typed keys: `*AUTHKEY*`/`TS_*KEY` must be `tskey-`, `TS_API_KEY` must be `tskey-api-`, `*_URL` must be `http(s)://`, `*_SERVICE_KEY`/`*_API_KEY` ≥ 16 chars.
- New `validate-env` job in `deploy-app.yml`; `build`, `provision-app`, and `provision-gateway` all `needs: validate-env` and gate on its success — so neither the build path nor the prebuilt-image (`image_ref`) path can skip it. Fails loudly if the env file is absent.
- `scripts/tests/validate-env-values.test.sh` — 16 cases (16/16 pass).

## Why
mcp#163: the MCP server crash-looped ~30h because GH secret `TS_EPHEMERAL_AUTHKEY` was set to `-` (a placeholder to satisfy a non-empty check) → `tailscale up --authkey=-` → container exit → 502. The existing `validate-required-secrets.sh` only checked non-empty (so `-` passed) and was never invoked. This gate closes that loophole and enforces it on every deploy.

bash 3.2-safe (macOS self-hosted runners). actionlint clean for the new job (pre-existing SC2129/SC2016 style notes elsewhere untouched).