### PR TITLE
feat(deploy): env-agnostic image naming + canonical 4-instance slot model (phase 1)

### DIFF
--- a/.github/workflows/deploy-app.yml
+++ b/.github/workflows/deploy-app.yml
@@ -175,19 +175,14 @@ jobs:
           if [ -n "${{ inputs.image_ref }}" ]; then
             IMAGE="${{ inputs.image_ref }}"
           else
-            IMAGE="${{ env.REGISTRY }}/${{ env.OWNER }}/img-${APP}-${ENV}:${TAG}"
+            IMAGE="${{ env.REGISTRY }}/${{ env.OWNER }}/img-${APP}:${TAG}"
           fi
 
           case "$ENV" in
-            prod)
+            prod|uat)
               BUILD_APP="${APP}-build"
               LIVE_APP="${APP}-live"
               STABLE_APP="${APP}-stable"
-              ;;
-            uat)
-              BUILD_APP="${APP}-uat-build"
-              LIVE_APP="${APP}-uat"
-              STABLE_APP="${APP}-uat-stable"
               ;;
             *)
               # Dev mirrors prod's full blue-green build -> live -> stable

--- a/.github/workflows/promote-to-live.yml
+++ b/.github/workflows/promote-to-live.yml
@@ -13,8 +13,8 @@ on:
         description: |
           Full GHCR image reference to deploy as live.
           Examples:
-            ghcr.io/qwickapps/img-billing-dev@sha256:<digest>
-            ghcr.io/qwickapps/img-documents-prod:1.0.0.42
+            ghcr.io/qwickapps/img-billing@sha256:<digest>
+            ghcr.io/qwickapps/img-documents:1.0.0.42
         required: true
         type: string
       image_name:
@@ -156,7 +156,7 @@ jobs:
           esac
 
           if [ -z "$IMAGE_NAME" ]; then
-            IMAGE_NAME="img-${APP}-${ENV}"
+            IMAGE_NAME="img-${APP}"
           fi
           if ! echo "$IMAGE_REF" | grep -Eq "^ghcr.io/qwickapps/${IMAGE_NAME}([:@])"; then
             echo "ERROR: image_ref does not match app/environment."

--- a/.github/workflows/promote-to-stable.yml
+++ b/.github/workflows/promote-to-stable.yml
@@ -163,7 +163,7 @@ jobs:
           esac
 
           if [ -z "$IMAGE_NAME" ]; then
-            IMAGE_NAME="img-${APP}-${ENV}"
+            IMAGE_NAME="img-${APP}"
           fi
           if ! echo "$IMAGE_REF" | grep -Eq "^ghcr.io/qwickapps/${IMAGE_NAME}([:@])"; then
             echo "ERROR: image_ref does not match app/environment."

--- a/.github/workflows/promote.yml
+++ b/.github/workflows/promote.yml
@@ -21,7 +21,7 @@ on:
         type: string
         required: true
       image_ref:
-        description: 'Full GHCR image reference to deploy (e.g. ghcr.io/qwickapps/img-mcp-dev:1.0.0.42)'
+        description: 'Full GHCR image reference to deploy (e.g. ghcr.io/qwickapps/img-mcp:1.0.0.42)'
         type: string
         required: true
       slot:


### PR DESCRIPTION
## Summary
- Removes environment suffix from image names in deploy and promote workflows
- Updates deploy slot synthesis to canonical 4-instance model: build -> live -> stable
- Keeps uat behavior on dedicated `${APP}-uat` CapRover slot while using canonical image naming

Closes #35