### PR TITLE
feat(validate): add Dockerfile node version parity check in Gate 3 (ci-workflows#25 G3)

### DIFF
--- a/.github/workflows/pr-validate.yml
+++ b/.github/workflows/pr-validate.yml
@@ -188,6 +188,23 @@ jobs:
         with:
           fetch-depth: 1
 
+      - name: Assert Dockerfile runtime version matches node_version input
+        if: ${{ inputs.has_dockerfile && inputs.language == 'ts' }}
+        run: |
+          DOCKERFILE="${{ inputs.dockerfile_path }}"
+          NODE_IN_FROM=$(grep -E '^FROM node:[0-9]' "$DOCKERFILE" | tail -1 | \
+            grep -oE 'node:[0-9]+' | cut -d: -f2 || true)
+          if [ -z "$NODE_IN_FROM" ]; then
+            echo "::notice::No versioned FROM node:XX found in $DOCKERFILE — skipping version parity check"
+            exit 0
+          fi
+          EXPECTED="${{ inputs.node_version }}"
+          if [ "$NODE_IN_FROM" != "$EXPECTED" ]; then
+            echo "::error::Version mismatch: Dockerfile uses node:${NODE_IN_FROM} but node_version input is ${EXPECTED}. Update dockerfile_path or node_version to match."
+            exit 1
+          fi
+          echo "Node version parity OK: FROM node:${NODE_IN_FROM} matches node_version=${EXPECTED}"
+
       - name: Install dependencies (TS)
         if: ${{ inputs.language == 'ts' }}
         run: pnpm install --frozen-lockfile

--- a/.github/workflows/pr-validate.yml
+++ b/.github/workflows/pr-validate.yml
@@ -188,23 +188,6 @@ jobs:
         with:
           fetch-depth: 1
 
-      - name: Assert Dockerfile runtime version matches node_version input
-        if: ${{ inputs.has_dockerfile && inputs.language == 'ts' }}
-        run: |
-          DOCKERFILE="${{ inputs.dockerfile_path }}"
-          NODE_IN_FROM=$(grep -E '^FROM node:[0-9]' "$DOCKERFILE" | tail -1 | \
-            grep -oE 'node:[0-9]+' | cut -d: -f2 || true)
-          if [ -z "$NODE_IN_FROM" ]; then
-            echo "::notice::No versioned FROM node:XX found in $DOCKERFILE — skipping version parity check"
-            exit 0
-          fi
-          EXPECTED="${{ inputs.node_version }}"
-          if [ "$NODE_IN_FROM" != "$EXPECTED" ]; then
-            echo "::error::Version mismatch: Dockerfile uses node:${NODE_IN_FROM} but node_version input is ${EXPECTED}. Update dockerfile_path or node_version to match."
-            exit 1
-          fi
-          echo "Node version parity OK: FROM node:${NODE_IN_FROM} matches node_version=${EXPECTED}"
-
       - name: Install dependencies (TS)
         if: ${{ inputs.language == 'ts' }}
         run: pnpm install --frozen-lockfile
@@ -240,6 +223,23 @@ jobs:
             exit 1
           fi
           echo "Dockerfile confirmed: ${{ inputs.dockerfile_path }}"
+
+      - name: Assert Dockerfile runtime version matches node_version input
+        if: ${{ inputs.has_dockerfile && inputs.language == 'ts' }}
+        run: |
+          DOCKERFILE="${{ inputs.dockerfile_path }}"
+          NODE_IN_FROM=$(grep -E '^FROM node:[0-9]' "$DOCKERFILE" | tail -1 | \
+            grep -oE 'node:[0-9]+' | cut -d: -f2 || true)
+          if [ -z "$NODE_IN_FROM" ]; then
+            echo "::notice::No versioned FROM node:XX found in $DOCKERFILE — skipping version parity check"
+            exit 0
+          fi
+          EXPECTED="${{ inputs.node_version }}"
+          if [ "$NODE_IN_FROM" != "$EXPECTED" ]; then
+            echo "::error::Version mismatch: Dockerfile uses node:${NODE_IN_FROM} but node_version input is ${EXPECTED}. Update dockerfile_path or node_version to match."
+            exit 1
+          fi
+          echo "Node version parity OK: FROM node:${NODE_IN_FROM} matches node_version=${EXPECTED}"
 
       - name: Install dependencies (TS)
         if: ${{ inputs.language == 'ts' }}


### PR DESCRIPTION
## Summary
- Adds a FROM version vs CI runtime parity check to Gate 3 in `pr-validate.yml`
- Extracts the LAST `FROM node:XX` from the Dockerfile (handles multi-stage builds)
- Fails Gate 3 if Dockerfile node version != `node_version` input
- Gracefully skips if no versioned node FROM found (`node:lts`, ARG-based, etc.)
- Only runs when `has_dockerfile: true` and `language: ts`
- Closes gap G3 from ci-workflows#25

## Test plan
- [ ] Dockerfile has `FROM node:24-alpine`, node_version=24 → pass
- [ ] Dockerfile has `FROM node:20-alpine`, node_version=24 → fail with clear error
- [ ] Dockerfile has `FROM node:lts-alpine` (no version number) → skip with notice
- [ ] Multi-stage: first FROM is `node:20-alpine` (builder), last is `FROM node:24-alpine` (runtime) → check last, pass when node_version=24