### PR TITLE
feat(validate): assert Dockerfile path exists in Gate 3 (ci-workflows#25 G2)

### DIFF
--- a/.github/workflows/pr-validate.yml
+++ b/.github/workflows/pr-validate.yml
@@ -215,6 +215,15 @@ jobs:
         with:
           fetch-depth: 1
 
+      - name: Assert Dockerfile exists at specified path
+        if: ${{ inputs.has_dockerfile }}
+        run: |
+          if [ ! -f "${{ inputs.dockerfile_path }}" ]; then
+            echo "::error::Dockerfile not found at '${{ inputs.dockerfile_path }}'. Check the dockerfile_path input in your caller workflow."
+            exit 1
+          fi
+          echo "Dockerfile confirmed: ${{ inputs.dockerfile_path }}"
+
       - name: Install dependencies (TS)
         if: ${{ inputs.language == 'ts' }}
         run: pnpm install --frozen-lockfile


### PR DESCRIPTION
## Summary
- Adds a Dockerfile existence pre-check to Gate 3 (build job) in `pr-validate.yml`
- Step runs only when `has_dockerfile: true`
- Fails early with a clear error if `dockerfile_path` doesn't exist in the repo
- Closes gap G2 from ci-workflows#25

## Test plan
- [ ] PR with `has_dockerfile: false` — step skipped
- [ ] PR with `has_dockerfile: true` and correct Dockerfile path — step passes
- [ ] PR with `has_dockerfile: true` and wrong dockerfile_path — step fails Gate 3 with clear error