### PR TITLE
feat(validate): add Go service type check (G4) and Next.js build gate (G6) in Gate 3 (ci-workflows#25)

### DIFF
--- a/.github/workflows/pr-validate.yml
+++ b/.github/workflows/pr-validate.yml
@@ -241,6 +241,33 @@ jobs:
           fi
           echo "Node version parity OK: FROM node:${NODE_IN_FROM} matches node_version=${EXPECTED}"
 
+      - name: Assert Go Dockerfile declares language=go (G4)
+        if: ${{ inputs.has_dockerfile }}
+        run: |
+          DOCKERFILE="${{ inputs.dockerfile_path }}"
+          FIRST_FROM=$(grep -m1 -E '^FROM [a-zA-Z0-9._/-]+' "$DOCKERFILE" | awk '{print $2}' || true)
+          if echo "$FIRST_FROM" | grep -qE '^golang:'; then
+            if [ "${{ inputs.language }}" != "go" ]; then
+              echo "::error::Dockerfile starts with FROM golang: but language input is '${{ inputs.language }}'. Set language: go in your pr-validate.yml caller to skip pnpm setup for this Go service."
+              exit 1
+            fi
+          fi
+          echo "Service type check passed (first FROM: ${FIRST_FROM:-unknown})"
+
+      - name: Assert Next.js project has build_command set (G6)
+        if: ${{ inputs.language == 'ts' }}
+        run: |
+          if [ ! -f "package.json" ]; then
+            exit 0
+          fi
+          if grep -q '"next"' package.json 2>/dev/null; then
+            if [ -z "${{ inputs.build_command }}" ]; then
+              echo "::error::Next.js project detected (package.json contains 'next') but build_command is empty. Set build_command: 'pnpm build' in your pr-validate.yml caller to validate the production build."
+              exit 1
+            fi
+          fi
+          echo "Next.js build gate check passed"
+
       - name: Install dependencies (TS)
         if: ${{ inputs.language == 'ts' }}
         run: pnpm install --frozen-lockfile


### PR DESCRIPTION
## Summary
- **G4**: Adds a Go service type consistency check to Gate 3. If the Dockerfile's first `FROM` is `golang:*`, asserts `language: go` is set in the caller workflow.
- **G6**: Adds a Next.js production build gate to Gate 3. If `package.json` declares `next` as a dependency, asserts `build_command` is not empty.
- Both checks run only when relevant (has_dockerfile for G4, language=ts for G6).
- Closes gaps G4 and G6 from ci-workflows#25.

## Test plan
- [ ] Go service (FROM golang:*) with language=go → G4 passes
- [ ] Go service (FROM golang:*) with language=ts → G4 fails with clear error
- [ ] Non-Go service → G4 skips
- [ ] Next.js repo with build_command set → G6 passes
- [ ] Next.js repo without build_command → G6 fails with clear error
- [ ] Non-Next.js TS repo → G6 skips
