### PR TITLE
feat: add opt-in live-only mode to deploy-app traffic-light flow

### DIFF
--- a/.github/workflows/deploy-app.yml
+++ b/.github/workflows/deploy-app.yml
@@ -86,6 +86,11 @@ on:
         required: true
 
       # -- Misc ------------------------------------------------------------------
+      promote_to_stable:
+        description: 'Whether traffic-light deploy should promote build -> live -> stable. Set false for live-only deploys where stable is managed separately on macmini.'
+        type: boolean
+        default: true
+
       run_migrations:
         description: 'Whether to run DB migrations during traffic-light deploy'
         type: string
@@ -802,6 +807,11 @@ jobs:
             fi
           fi
 
+          PROMOTE_STABLE_ARGS=()
+          if [ "${{ inputs.promote_to_stable }}" = "false" ]; then
+            PROMOTE_STABLE_ARGS+=(--promote-to-stable false)
+          fi
+
           .github/scripts/deploy-traffic-light.sh \
             --product           "${{ inputs.app_name }}" \
             --environment       "${{ inputs.environment }}" \
@@ -816,7 +826,8 @@ jobs:
             --run-migrations      "${{ inputs.run_migrations }}" \
             --run-e2e             "${{ inputs.run_e2e }}" \
             --critical-subsystems "$EFFECTIVE_CRITICAL" \
-            --warning-subsystems  "$EFFECTIVE_WARNING"
+            --warning-subsystems  "$EFFECTIVE_WARNING" \
+            "${PROMOTE_STABLE_ARGS[@]}"
 
       - name: Point gateway at live slot
         run: |


### PR DESCRIPTION
## Summary
- Adds new `workflow_call` input `promote_to_stable` to `deploy-app.yml` (default `true`) to keep current behavior unchanged unless explicitly opted into live-only.
- Threads this input into `traffic-light-deploy` as `--promote-to-stable false` when disabled.
- This is non-breaking: default and existing callers without explicit override keep full `build -> live -> stable` promotion behavior.

## Protocol alignment
- Implements the `protocols#308` live-only direction: traffic-light deployment moves build image to `-live` and gates routing, while `-stable` promotion remains a separate, manually managed macmini follow-up step.

## Notes
- The canonical script that performs swap/promotion lives in caller repos (for example `mcp`) and must understand `--promote-to-stable` for live-only opt-in to take effect.
- Caller-side behavioral test coverage has been added/updated in `mcp/.github/scripts/test-deploy-traffic-light.sh` to cover both default promotion and live-only skip behavior.
- Actionlint was run on `deploy-app.yml`; shellcheck style warnings currently reported in unchanged file sections are pre-existing.
