### PR TITLE
fix: use pre-installed protocols path in drift-check (drop cross-repo checkout)

### DIFF
--- a/.github/workflows/promote-to-live.yml
+++ b/.github/workflows/promote-to-live.yml
@@ -71,12 +71,12 @@ jobs:
       - name: Checkout caller repo
         uses: actions/checkout@v4
 
-      - name: Checkout protocols
-        uses: actions/checkout@v4
-        with:
-          repository: qwickapps/protocols
-          ref: main
-          path: .protocols
+      - name: Verify protocols runtime available
+        run: |
+          if [[ ! -f ~/.qwickapps/protocols/scripts/check-runtime-drift.sh ]]; then
+            echo "::error::~/.qwickapps/protocols/scripts/check-runtime-drift.sh not found. Ensure install-fleet CI ran successfully."
+            exit 1
+          fi
 
       - name: Resolve CapRover credentials for drift check
         run: |
@@ -119,8 +119,7 @@ jobs:
 
       - name: Run runtime drift check
         run: |
-          chmod +x .protocols/scripts/check-runtime-drift.sh
-          .protocols/scripts/check-runtime-drift.sh \
+          ~/.qwickapps/protocols/scripts/check-runtime-drift.sh \
             --app-name "$DRIFT_APP_NAME" \
             --host caprover \
             --caprover-url "$DRIFT_CAPROVER_URL" \

--- a/.github/workflows/promote-to-stable.yml
+++ b/.github/workflows/promote-to-stable.yml
@@ -72,12 +72,12 @@ jobs:
       - name: Checkout caller repo
         uses: actions/checkout@v4
 
-      - name: Checkout protocols
-        uses: actions/checkout@v4
-        with:
-          repository: qwickapps/protocols
-          ref: main
-          path: .protocols
+      - name: Verify protocols runtime available
+        run: |
+          if [[ ! -f ~/.qwickapps/protocols/scripts/check-runtime-drift.sh ]]; then
+            echo "::error::~/.qwickapps/protocols/scripts/check-runtime-drift.sh not found. Ensure install-fleet CI ran successfully."
+            exit 1
+          fi
 
       - name: Resolve CapRover credentials for drift check
         run: |
@@ -127,8 +127,7 @@ jobs:
 
       - name: Run runtime drift check
         run: |
-          chmod +x .protocols/scripts/check-runtime-drift.sh
-          .protocols/scripts/check-runtime-drift.sh \
+          ~/.qwickapps/protocols/scripts/check-runtime-drift.sh \
             --app-name "$DRIFT_APP_NAME" \
             --host caprover \
             --caprover-url "$DRIFT_CAPROVER_URL" \


### PR DESCRIPTION
## Problem

`promote-to-stable` and `promote-to-live` drift-check jobs fail with:

```
repository 'https://github.com/qwickapps/protocols/' not found
```

Root cause: `actions/checkout@v4` against a private repo requires an explicit `token:`. In a reusable workflow, `GITHUB_TOKEN` is scoped to the **caller** repo (e.g. `qwickapps/mcp`), not `qwickapps/protocols`, so the checkout gets a 128 / not-found.

Blocked `qwickapps/mcp#192` → blocked LinkedIn plugin promotion (`mcp#191` merged to main, image built, but stuck at drift-check gate).

## Fix

Replace the `Checkout protocols` step with a `Verify protocols runtime available` check against `~/.qwickapps/protocols/` — the same pre-installed path already used by `deploy-preflight.yml`. No token needed; the macmini runner has protocols installed via `install-fleet` CI.

## Changes

- `promote-to-stable.yml` — remove `Checkout protocols`, use `~/.qwickapps/protocols/scripts/check-runtime-drift.sh`
- `promote-to-live.yml` — same fix

## Test plan

- [ ] Merge this PR
- [ ] Re-run `promote-to-stable.yml` on qwickapps/mcp for LinkedIn plugin image
- [ ] Confirm drift-check passes (or fails for a real drift reason, not checkout error)

Closes qwickapps/mcp#192