### PR TITLE
fix: use local ~/.qwickapps/protocols for drift-check instead of GitHub clone

### DIFF
--- a/.github/workflows/promote-to-stable.yml
+++ b/.github/workflows/promote-to-stable.yml
@@ -72,12 +72,12 @@ jobs:
       - name: Checkout caller repo
         uses: actions/checkout@v4
 
-      - name: Checkout protocols
-        uses: actions/checkout@v4
-        with:
-          repository: qwickapps/protocols
-          ref: main
-          path: .protocols
+      - name: Verify protocols runtime available
+        run: |
+          if [[ ! -f ~/.qwickapps/protocols/scripts/check-runtime-drift.sh ]]; then
+            echo "::error::~/.qwickapps/protocols/scripts/check-runtime-drift.sh not found. Ensure install-fleet CI ran successfully on this runner."
+            exit 1
+          fi
 
       - name: Resolve CapRover credentials for drift check
         run: |
@@ -127,8 +127,7 @@ jobs:
 
       - name: Run runtime drift check
         run: |
-          chmod +x .protocols/scripts/check-runtime-drift.sh
-          .protocols/scripts/check-runtime-drift.sh \
+          ~/.qwickapps/protocols/scripts/check-runtime-drift.sh \
             --app-name "$DRIFT_APP_NAME" \
             --host caprover \
             --caprover-url "$DRIFT_CAPROVER_URL" \


### PR DESCRIPTION
## Summary

- Replace the `Checkout protocols` step (which clones `qwickapps/protocols` from GitHub) with a `Verify protocols runtime available` step that asserts `~/.qwickapps/protocols/scripts/check-runtime-drift.sh` exists
- Update `Run runtime drift check` to call `~/.qwickapps/protocols/scripts/check-runtime-drift.sh` directly (same as `deploy-preflight.yml`)

## Root cause

`qwickapps/protocols` is a private repository. `actions/checkout@v4` with the default `GITHUB_TOKEN` (scoped to the calling repo) returns "repository not found". This broke every `promote-to-stable` drift-check.

The macmini runner already has protocols installed at `~/.qwickapps/protocols` via `install-fleet CI`. `deploy-preflight.yml` uses this path and never clones from GitHub. This PR applies the same pattern to `promote-to-stable.yml`.

## Test plan

- [ ] Re-run `promote-to-stable` on qwickapps/mcp
- [ ] `Verify protocols runtime available` step passes
- [ ] Drift check runs `check-runtime-drift.sh` and completes

Closes qwickapps/mcp#192

🤖 Generated with [Claude Code](https://claude.com/claude-code)