### PR TITLE
fix(validate): accept any scheme:// for *_URL keys (postgres, redis, etc.)

### DIFF
--- a/scripts/tests/validate-env-values.test.sh
+++ b/scripts/tests/validate-env-values.test.sh
@@ -92,7 +92,7 @@ assert_fail "TS authkey not starting tskey- rejected" \
   "TS_EPHEMERAL_AUTHKEY=not-a-tailscale-key-value"
 assert_fail "TS_API_KEY not starting tskey-api- rejected" \
   "TS_API_KEY=tskey-auth-wrong-prefix-1234567890"
-assert_fail "_URL not starting http rejected" \
+assert_fail "_URL with no scheme rejected" \
   "SECRETS_SERVICE_URL=secrets.qwickforge.com"
 assert_fail "short _SERVICE_KEY rejected" \
   "SECRETS_SERVICE_KEY=short"
@@ -102,6 +102,10 @@ assert_fail "short _API_KEY rejected" \
 echo "== validate-env-values: well-formed typed keys pass =="
 assert_pass "TS_API_KEY with tskey-api- prefix passes" \
   "TS_API_KEY=tskey-api-1234567890abcdef"
+assert_pass "DATABASE_URL with postgres:// scheme passes" \
+  "DATABASE_URL=postgres://user:pass@host:5432/db?sslmode=require"
+assert_pass "_URL with redis:// scheme passes" \
+  "REDIS_URL=redis://localhost:6379"
 assert_pass "comment + blank lines only passes (no values)" \
   "# only a comment"
 assert_pass "value containing = passes" \

--- a/scripts/validate-env-values.sh
+++ b/scripts/validate-env-values.sh
@@ -168,11 +168,12 @@ while IFS= read -r line || [ -n "$line" ]; do
     esac
   fi
 
-  # 3b. URLs must start with http:// or https://.
+  # 3b. URLs must contain a scheme (scheme://). Allows http, https, postgres,
+  # postgresql, redis, mysql, etc. — rejects bare hostnames with no scheme.
   if [[ "$key_uc" == *_URL ]]; then
     case "$value_trimmed" in
-      http://*|https://*) ;;
-      *) report "$key" "URL must start with http:// or https://" ; continue ;;
+      *://*) ;;
+      *) report "$key" "URL must contain a scheme (e.g. https://, postgres://)" ; continue ;;
     esac
   fi
 


### PR DESCRIPTION
## Summary

- `validate-env-values.sh` was rejecting `DATABASE_URL` with a `postgres://` connection string
- The URL check was http/https-only; any other scheme (`postgres://`, `redis://`, `mysql://`, etc.) triggered a validation failure
- Secrets deploy run 26925501505 failed with: `DATABASE_URL: URL must start with http:// or https://`

## Root cause

The `*_URL` pattern check validated with `http://*|https://*`. `DATABASE_URL` is a PostgreSQL URI (`postgres://...`), which is a perfectly valid URL with a non-HTTP scheme.

## Fix

Accept any `scheme://` format for `*_URL` keys. Bare hostnames with no scheme (e.g., `secrets.qwickforge.com`) are still rejected.

## Test plan

- [x] `bash scripts/tests/validate-env-values.test.sh` — 18/18 pass (2 new: `DATABASE_URL=postgres://...` passes, `REDIS_URL=redis://...` passes)
- [ ] Re-trigger secrets deploy after ci-workflows submodule is bumped in qwickapps/secrets

🤖 Generated with [Claude Code](https://claude.com/claude-code)