### PR TITLE
fix(deploy): correct UAT slot names in prepare step

### DIFF
--- a/.github/workflows/deploy-app.yml
+++ b/.github/workflows/deploy-app.yml
@@ -184,10 +184,15 @@ jobs:
           fi
 
           case "$ENV" in
-            prod|uat)
+            prod)
               BUILD_APP="${APP}-build"
               LIVE_APP="${APP}-live"
               STABLE_APP="${APP}-stable"
+              ;;
+            uat)
+              BUILD_APP="${APP}-uat-build"
+              LIVE_APP="${APP}-uat"
+              STABLE_APP="${APP}-uat-stable"
               ;;
             *)
               # Dev mirrors prod's full blue-green build -> live -> stable


### PR DESCRIPTION
## Summary

- Splits the combined `prod|uat)` case in the `Generate image metadata` step into separate `prod)` and `uat)` branches
- UAT now emits `{APP}-uat-build`, `{APP}-uat`, and `{APP}-uat-stable` as expected by `deploy-traffic-light.sh`
- Prod slot names are unchanged: `{APP}-build`, `{APP}-live`, `{APP}-stable`
- The downstream `Derive URLs` step already had a correct separate `uat)` branch and reads slot names from `meta` outputs — no changes needed there; URLs are automatically correct once `meta` emits the right names

Closes #61