### PR TITLE
fix(ci): persist-credentials:false for submodule checkout (macOS runner)

### DIFF
--- a/.github/workflows/main-push-guard.yml
+++ b/.github/workflows/main-push-guard.yml
@@ -105,6 +105,11 @@ jobs:
       - uses: actions/checkout@v4
         with:
           submodules: true
+          # .ci-workflows is CI tooling, not app code. Skip persisting the auth
+          # header into the submodule — that step fails on the macOS self-hosted
+          # runner ("Unable to replace auth placeholder in .git/config"). The
+          # submodule is still fetched; build/test are read-only and don't push.
+          persist-credentials: false
 
       - name: Setup Node.js
         if: inputs.language == 'ts' || inputs.language == 'js'
@@ -148,6 +153,9 @@ jobs:
         uses: actions/checkout@v4
         with:
           submodules: true
+          # See note above: skip submodule credential-persist (fails on macOS
+          # self-hosted runner; submodule is still fetched, build is read-only).
+          persist-credentials: false
 
       - name: Generate image metadata
         id: meta


### PR DESCRIPTION
main-push-guard Test+Build checkouts fail on the macmini (macOS) self-hosted runner persisting the auth header into the .ci-workflows submodule: `Unable to replace auth placeholder in .git/config`. The submodule is CI tooling (not app code) and these jobs are read-only, so `persist-credentials: false` is safe — the submodule is still fetched, just no credential persist. Unblocks the blue-green rollout build-once for all 5 services (all carry the .ci-workflows submodule). actionlint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)