### PR TITLE
fix(ci): pnpm install --force (self-hosted toolcache EEXIST)

### DIFF
--- a/.github/workflows/main-push-guard.yml
+++ b/.github/workflows/main-push-guard.yml
@@ -119,7 +119,9 @@ jobs:
 
       - name: Install pnpm
         if: inputs.language == 'ts' || inputs.language == 'js'
-        run: npm install -g pnpm
+        # --force overwrites stale pnpm/pnpx symlinks left in the reused node
+        # toolcache on the self-hosted runner (npm errors EEXIST otherwise).
+        run: npm install -g pnpm --force
 
       - name: Install dependencies
         if: inputs.language == 'ts' || inputs.language == 'js'


### PR DESCRIPTION
Next main-push-guard runner issue after #66: `npm install -g pnpm` fails EEXIST against stale pnpm/pnpx symlinks in the reused node toolcache. `--force` overwrites them. actionlint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)