### PR TITLE
feat(hygiene): org-wide daily branch + PR hygiene sweep

### DIFF
--- a/.github/workflows/org-branch-hygiene.yml
+++ b/.github/workflows/org-branch-hygiene.yml
@@ -1,0 +1,60 @@
+name: "Org-Wide Branch Hygiene"
+
+on:
+  schedule:
+    # Run daily at 03:00 UTC
+    - cron: "0 3 * * *"
+  workflow_dispatch:
+    inputs:
+      dry_run:
+        description: "Dry run (report only, no deletions)"
+        required: false
+        type: boolean
+        default: false
+      stale_days:
+        description: "Days without commits before a branch is flagged as old (default: 21)"
+        required: false
+        type: string
+        default: "21"
+
+# Minimal permissions: read org repos + write repo contents for branch deletion
+permissions:
+  contents: write
+
+jobs:
+  sweep:
+    name: "Sweep all qwickapps repos"
+    runs-on: [self-hosted, macmini]
+    timeout-minutes: 30
+
+    steps:
+      - name: "Hygiene before checkout"
+        run: |
+          git config --global --add safe.directory '*' 2>/dev/null || true
+          git clean -ffd 2>/dev/null || true
+
+      - name: "Checkout ci-workflows (for scripts)"
+        uses: actions/checkout@v4
+        with:
+          token: ${{ secrets.ORG_HYGIENE_TOKEN }}
+
+      - name: "Run org-wide branch hygiene sweep"
+        id: sweep
+        env:
+          GH_TOKEN: ${{ secrets.ORG_HYGIENE_TOKEN }}
+          DRY_RUN: ${{ inputs.dry_run || 'false' }}
+          STALE_DAYS: ${{ inputs.stale_days || '21' }}
+          ORG: qwickapps
+        run: python3 scripts/org-branch-hygiene.py --org "$ORG" --stale-days "$STALE_DAYS" $( [ "$DRY_RUN" = "true" ] && echo "--dry-run" ) --output /tmp/hygiene-report.json
+
+      - name: "Write job summary"
+        if: always()
+        run: python3 scripts/org-branch-hygiene-summary.py /tmp/hygiene-report.json "$GITHUB_STEP_SUMMARY"
+
+      - name: "Upload report artifact"
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: hygiene-report-${{ github.run_id }}
+          path: /tmp/hygiene-report.json
+          retention-days: 30

--- a/scripts/org-branch-hygiene-summary.py
+++ b/scripts/org-branch-hygiene-summary.py
@@ -1,0 +1,69 @@
+#!/usr/bin/env python3
+"""org-branch-hygiene-summary.py — Write job summary from hygiene report JSON."""
+import json, sys, os
+
+report_path = sys.argv[1] if len(sys.argv) > 1 else "/tmp/hygiene-report.json"
+summary_path = sys.argv[2] if len(sys.argv) > 2 else os.environ.get("GITHUB_STEP_SUMMARY", "/dev/stdout")
+
+if not os.path.exists(report_path):
+    print("No report file found at", report_path)
+    sys.exit(0)
+
+with open(report_path) as f:
+    r = json.load(f)
+
+with open(summary_path, "a") as out:
+    out.write("# Org-Wide Branch Hygiene Report\n\n")
+    out.write(f"**Run date:** {r.get('run_date', 'unknown')}  \n")
+    out.write(f"**Dry run:** {r.get('dry_run', False)}  \n")
+    out.write(f"**Repos scanned:** {r.get('repos_scanned', 0)}  \n")
+    out.write(f"**Branches scanned:** {r.get('branches_scanned', 0)}  \n\n")
+    out.write("---\n\n")
+
+    deleted = r.get("deleted", [])
+    out.write(f"## Deleted (provably merged into default): {len(deleted)}\n\n")
+    out.write("> Safety predicate: `compare/{default}...{branch}` returned `behind` or `identical` ")
+    out.write("(zero unmerged commits). Open PR heads were never touched.\n\n")
+    if deleted:
+        by_repo = {}
+        for item in deleted:
+            by_repo.setdefault(item["repo"], []).append(item["branch"])
+        out.write("| Repo | Branches Deleted |\n|------|------------------|\n")
+        for repo, branches in sorted(by_repo.items(), key=lambda x: -len(x[1])):
+            out.write(f"| `{repo}` | {', '.join(f'`{b}`' for b in branches)} |\n")
+    else:
+        out.write("_None — no provably-merged branches found._\n")
+    out.write("\n")
+
+    flagged = r.get("flagged_for_review", [])
+    stale_days = r.get("stale_days", 21)
+    out.write(f"## Flagged for human review (>{stale_days}d old, unmerged — NOT deleted): {len(flagged)}\n\n")
+    out.write("> These branches have commits not in the default branch. They are listed here for review only.\n\n")
+    if flagged:
+        out.write("| Repo | Branch | Last Commit | Days Old | Ahead | Compare Status |\n")
+        out.write("|------|--------|-------------|----------|-------|----------------|\n")
+        for item in sorted(flagged, key=lambda x: x.get("days_old", 0), reverse=True)[:60]:
+            out.write(
+                f"| `{item['repo']}` | `{item['branch']}` | {item.get('last_commit','?')} "
+                f"| {item.get('days_old','?')} | {item.get('ahead','?')} | {item.get('status','?')} |\n"
+            )
+        if len(flagged) > 60:
+            out.write(f"\n_...and {len(flagged)-60} more — see the full report artifact._\n")
+    else:
+        out.write("_None._\n")
+    out.write("\n")
+
+    stale_prs = r.get("stale_prs", [])
+    out.write(f"## Stale open PRs (>{stale_days}d no update — NOT closed): {len(stale_prs)}\n\n")
+    if stale_prs:
+        out.write("| Repo | PR | Days Stale | Author | Title |\n")
+        out.write("|------|-----|------------|--------|-------|\n")
+        for pr in sorted(stale_prs, key=lambda x: -x.get("days_stale", 0)):
+            out.write(
+                f"| `{pr['repo']}` | #{pr['number']} | {pr['days_stale']}d "
+                f"| {pr.get('author','')} | {pr.get('title','')[:55]} |\n"
+            )
+    else:
+        out.write("_None._\n")
+
+print(f"Summary written to {summary_path}")

--- a/scripts/org-branch-hygiene.py
+++ b/scripts/org-branch-hygiene.py
@@ -1,0 +1,271 @@
+#!/usr/bin/env python3
+"""org-branch-hygiene.py — Org-wide branch and PR hygiene sweeper.
+
+Safety predicate:
+  A branch is PROVABLY MERGED (safe to delete) if and only if:
+    GET /repos/{org}/{repo}/compare/{default}...{branch}
+    returns status == "behind" OR status == "identical"
+  (i.e. the branch has ZERO commits that are not already in the default branch)
+
+  We additionally skip:
+    - The repo's default branch
+    - Any branch whose name is in PROTECTED_NAMES
+    - Any branch that is the HEAD of an open PR (never delete open PR branches)
+
+  When in doubt — any other compare status — we FLAG, never delete.
+"""
+
+import argparse
+import json
+import os
+import subprocess
+import sys
+from datetime import datetime, timezone, timedelta
+
+PROTECTED_NAMES = {
+    "main", "master", "dev", "staging", "production", "develop",
+    "v5-stable", "docs/readme", "aal-1-bash-intercept",
+}
+
+
+def gh(endpoint, method="GET", accept_not_found=False):
+    """Call `gh api <endpoint>`, return parsed JSON or None on 404."""
+    r = subprocess.run(
+        ["gh", "api", "--paginate", endpoint],
+        capture_output=True, text=True,
+    )
+    if r.returncode != 0:
+        if accept_not_found and "404" in r.stderr:
+            return None
+        return None
+    try:
+        # gh --paginate can emit multiple JSON arrays; merge them
+        text = r.stdout.strip()
+        if text.startswith("["):
+            # Could be multiple arrays concatenated by --paginate
+            merged = []
+            decoder = json.JSONDecoder()
+            pos = 0
+            while pos < len(text):
+                text_from = text[pos:].lstrip()
+                if not text_from:
+                    break
+                obj, idx = decoder.raw_decode(text_from)
+                pos += len(text) - len(text_from) + idx
+                if isinstance(obj, list):
+                    merged.extend(obj)
+                else:
+                    merged.append(obj)
+            return merged
+        return json.loads(text)
+    except Exception:
+        return None
+
+
+def gh_single(endpoint, jq_filter=None):
+    """Call gh api without --paginate, optionally with --jq."""
+    args = ["gh", "api", endpoint]
+    if jq_filter:
+        args += ["--jq", jq_filter]
+    r = subprocess.run(args, capture_output=True, text=True)
+    if r.returncode != 0:
+        return None
+    text = r.stdout.strip()
+    if not text:
+        return None
+    if jq_filter:
+        return text  # raw string output from jq
+    try:
+        return json.loads(text)
+    except Exception:
+        return text
+
+
+def compare_branch(org, repo, default, branch):
+    """Return (status, ahead_by) or (None, None) on error."""
+    r = subprocess.run(
+        ["gh", "api", f"repos/{org}/{repo}/compare/{default}...{branch}",
+         "--jq", "{status:.status,ahead:.ahead_by}"],
+        capture_output=True, text=True,
+    )
+    if r.returncode != 0:
+        return None, None
+    try:
+        data = json.loads(r.stdout.strip())
+        return data.get("status"), data.get("ahead", -1)
+    except Exception:
+        return None, None
+
+
+def get_open_pr_heads(org, repo):
+    """Return set of branch names that are heads of open PRs."""
+    prs = gh(f"repos/{org}/{repo}/pulls?state=open&per_page=100")
+    if not prs:
+        return set()
+    return {pr["head"]["ref"] for pr in prs if isinstance(pr, dict)}
+
+
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--org", default="qwickapps")
+    parser.add_argument("--stale-days", type=int, default=21)
+    parser.add_argument("--dry-run", action="store_true")
+    parser.add_argument("--output", default="/tmp/hygiene-report.json")
+    args = parser.parse_args()
+
+    org = args.org
+    stale_days = args.stale_days
+    dry_run = args.dry_run or os.environ.get("DRY_RUN", "false").lower() == "true"
+    cutoff = datetime.now(timezone.utc) - timedelta(days=stale_days)
+
+    print(f"[hygiene] org={org} stale_days={stale_days} dry_run={dry_run}")
+
+    # --- Enumerate repos ---
+    repos_raw = gh(f"orgs/{org}/repos?type=all&per_page=100")
+    if not repos_raw:
+        print("[hygiene] ERROR: could not list repos", file=sys.stderr)
+        sys.exit(1)
+
+    active_repos = []
+    for r in repos_raw:
+        if r.get("archived"):
+            continue
+        name = r.get("name", "")
+        default = r.get("default_branch", "")
+        if name and default:
+            active_repos.append((name, default))
+
+    print(f"[hygiene] {len(active_repos)} active repos")
+
+    deleted = []
+    flagged_for_review = []
+    stale_prs = []
+    branches_scanned = 0
+
+    for repo_name, default_branch in active_repos:
+        # Get all open PR heads (to never delete)
+        open_heads = get_open_pr_heads(org, repo_name)
+
+        # Get all branches
+        branches_raw = gh(f"repos/{org}/{repo_name}/branches?per_page=100")
+        if not branches_raw:
+            continue
+
+        for br_obj in branches_raw:
+            if not isinstance(br_obj, dict):
+                continue
+            branch = br_obj.get("name", "")
+            if not branch:
+                continue
+            if branch == default_branch:
+                continue
+            if branch in PROTECTED_NAMES:
+                continue
+            if branch in open_heads:
+                continue
+
+            branches_scanned += 1
+
+            # --- Safety predicate ---
+            cmp_status, ahead_by = compare_branch(org, repo_name, default_branch, branch)
+
+            if cmp_status in ("behind", "identical"):
+                # PROVABLY MERGED — safe to delete
+                if not dry_run:
+                    del_r = subprocess.run(
+                        ["gh", "api", f"repos/{org}/{repo_name}/git/refs/heads/{branch}",
+                         "-X", "DELETE"],
+                        capture_output=True, text=True,
+                    )
+                    success = del_r.returncode == 0
+                else:
+                    success = True  # dry run
+
+                deleted.append({
+                    "repo": repo_name,
+                    "branch": branch,
+                    "default": default_branch,
+                    "status": cmp_status,
+                    "dry_run": dry_run,
+                    "deleted": success,
+                })
+                verb = "[DRY-RUN would delete]" if dry_run else "[DELETED]"
+                print(f"  {verb} {repo_name}/{branch} (compare={cmp_status})")
+            else:
+                # Check last commit date for staleness
+                last_commit_r = subprocess.run(
+                    ["gh", "api",
+                     f"repos/{org}/{repo_name}/commits?sha={branch}&per_page=1",
+                     "--jq", ".[0].commit.committer.date"],
+                    capture_output=True, text=True,
+                )
+                last_date_str = last_commit_r.stdout.strip().strip('"')
+                try:
+                    last_date = datetime.fromisoformat(last_date_str.replace("Z", "+00:00"))
+                    days_old = (datetime.now(timezone.utc) - last_date).days
+                    last_date_short = last_date_str[:10]
+                except Exception:
+                    days_old = 0
+                    last_date_short = "unknown"
+
+                if days_old >= stale_days:
+                    flagged_for_review.append({
+                        "repo": repo_name,
+                        "branch": branch,
+                        "default": default_branch,
+                        "status": cmp_status,
+                        "ahead": ahead_by,
+                        "last_commit": last_date_short,
+                        "days_old": days_old,
+                    })
+
+        # --- Stale open PRs ---
+        prs_raw = gh(f"repos/{org}/{repo_name}/pulls?state=open&per_page=100")
+        if prs_raw:
+            for pr in prs_raw:
+                if not isinstance(pr, dict):
+                    continue
+                updated_str = pr.get("updated_at", "")
+                try:
+                    updated = datetime.fromisoformat(updated_str.replace("Z", "+00:00"))
+                    if updated < cutoff:
+                        days_stale = (datetime.now(timezone.utc) - updated).days
+                        stale_prs.append({
+                            "repo": repo_name,
+                            "number": pr["number"],
+                            "title": pr.get("title", "")[:80],
+                            "author": pr.get("user", {}).get("login", ""),
+                            "head": pr.get("head", {}).get("ref", ""),
+                            "days_stale": days_stale,
+                            "updated_at": updated_str[:10],
+                        })
+                except Exception:
+                    pass
+
+    # --- Write report ---
+    report = {
+        "run_date": datetime.now(timezone.utc).isoformat(),
+        "org": org,
+        "dry_run": dry_run,
+        "stale_days": stale_days,
+        "repos_scanned": len(active_repos),
+        "branches_scanned": branches_scanned,
+        "deleted": deleted,
+        "flagged_for_review": flagged_for_review,
+        "stale_prs": stale_prs,
+        "summary": {
+            "deleted_count": len(deleted),
+            "flagged_count": len(flagged_for_review),
+            "stale_pr_count": len(stale_prs),
+        },
+    }
+
+    with open(args.output, "w") as f:
+        json.dump(report, f, indent=2)
+
+    print(f"\n[hygiene] SUMMARY: deleted={len(deleted)} flagged={len(flagged_for_review)} stale_prs={len(stale_prs)}")
+    print(f"[hygiene] Report written to {args.output}")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary

- Adds a single scheduled workflow (`org-branch-hygiene.yml`) that sweeps **all active qwickapps repos** from one runner every night at 03:00 UTC, plus on `workflow_dispatch` with a `dry_run` toggle.
- Adds `scripts/org-branch-hygiene.py` (the sweep engine) and `scripts/org-branch-hygiene-summary.py` (the job summary formatter), following the existing `scripts/` convention.

## What it does

**Deletes** branches that are PROVABLY STALE = status `behind` or `identical` on  
`GET /repos/{org}/{repo}/compare/{default}...{branch}` (zero commits not in default).

**Never deletes:**
- The repo's default branch
- Branches named `main`, `master`, `dev`, `staging`, `production`, `develop`, `v5-stable`, `docs/readme`, `aal-1-bash-intercept`
- Any branch that is the HEAD of an open PR

**Flags for human review** (listed in job summary, NOT deleted):
- Branches older than 21 days with unmerged commits (`ahead` or `diverged`)

**Reports stale open PRs** (>21 days no update, NOT auto-closed) for visibility.

Produces a GitHub Actions job summary table and a JSON artifact retained for 30 days.

## Required secret

The workflow requires `secrets.ORG_HYGIENE_TOKEN` — a classic PAT with `repo` + `delete_branch` scopes, org-level access. Add this to the `ci-workflows` repo secrets before the first scheduled run.

## Reference

Generalised from the existing `post-merge-cleanup.yml` in `raajkumars/qwickapps`. Same safety logic; extended to sweep the entire org from one place instead of 68 per-repo callers.

## Test plan

- [ ] Confirm `scripts/org-branch-hygiene.py --dry-run` output looks correct
- [ ] Add `ORG_HYGIENE_TOKEN` secret to the repo
- [ ] Run via `workflow_dispatch` with `dry_run: true` and review the job summary
- [ ] Run once live and verify only merged branches are deleted

🤖 Generated with [Claude Code](https://claude.com/claude-code)