### PR TITLE
fix(promote-live): use pre-installed protocols path in drift-check

### DIFF
--- a/.github/workflows/promote-to-live.yml
+++ b/.github/workflows/promote-to-live.yml
@@ -71,12 +71,12 @@ jobs:
       - name: Checkout caller repo
         uses: actions/checkout@v4
 
-      - name: Checkout protocols
-        uses: actions/checkout@v4
-        with:
-          repository: qwickapps/protocols
-          ref: main
-          path: .protocols
+      - name: Verify protocols runtime available
+        run: |
+          if [[ ! -f ~/.qwickapps/protocols/scripts/check-runtime-drift.sh ]]; then
+            echo "::error::~/.qwickapps/protocols/scripts/check-runtime-drift.sh not found. Ensure install-fleet CI ran successfully on this runner."
+            exit 1
+          fi
 
       - name: Resolve CapRover credentials for drift check
         run: |
@@ -119,8 +119,7 @@ jobs:
 
       - name: Run runtime drift check
         run: |
-          chmod +x .protocols/scripts/check-runtime-drift.sh
-          .protocols/scripts/check-runtime-drift.sh \
+          ~/.qwickapps/protocols/scripts/check-runtime-drift.sh \
             --app-name "$DRIFT_APP_NAME" \
             --host caprover \
             --caprover-url "$DRIFT_CAPROVER_URL" \


### PR DESCRIPTION
## Summary

`promote-to-live.yml` still had a broken `Checkout protocols` step that uses `actions/checkout@v4` without a token for the private `qwickapps/protocols` repo. The default `GITHUB_TOKEN` in a reusable workflow is scoped to the *caller* repo, so this checkout fails with "repository not found".

This is the same fix already applied to `promote-to-stable.yml` in PR #58 (committed as `46c6b73`). This PR applies the identical pattern to `promote-to-live.yml`.

**Change:** Replace `actions/checkout@v4` for protocols with a `Verify protocols runtime available` step that checks `~/.qwickapps/protocols/scripts/check-runtime-drift.sh` exists on the self-hosted runner (always installed via install-fleet CI).

Supersedes PR #56 (which had a merge conflict because PR #58 already fixed `promote-to-stable.yml` with the same approach).

## Test plan
- [x] `promote-to-stable.yml` already uses this pattern (deployed by PR #58) — no drift-check auth failures observed
- [x] `promote-to-live.yml` now uses the same pattern
- [x] SKIP: live promotion test requires an active deploy pipeline on self-hosted runner