### PR TITLE
fix(bluegreen): force TS_HOSTNAME for build slots + fix promote health probe

### DIFF
--- a/.github/workflows/promote-to-live.yml
+++ b/.github/workflows/promote-to-live.yml
@@ -220,6 +220,9 @@ jobs:
           echo "CAPROVER_PASSWORD=${CAPROVER_PASSWORD}" >> "$GITHUB_ENV"
           echo "LIVE_APP_URL=${LIVE_APP_URL}"           >> "$GITHUB_ENV"
           echo "GHCR_PULL_TOKEN=${{ secrets.GHCR_PULL_TOKEN }}" >> "$GITHUB_ENV"
+          # Tailnet node URL for health checks — CapRover public domain
+          # returns 404 before the domain is bound to the slot.
+          echo "TAILNET_HEALTH_URL=http://${LIVE_APP}.taile324e7.ts.net:8080" >> "$GITHUB_ENV"
 
       - name: Checkout code
         uses: actions/checkout@v4
@@ -239,7 +242,7 @@ jobs:
 
       - name: Validate live slot health
         run: |
-          HEALTH_URL="${LIVE_APP_URL}${HEALTH_PATH}"
+          HEALTH_URL="${TAILNET_HEALTH_URL}${HEALTH_PATH}"
           echo "Waiting for ${HEALTH_URL} to become healthy..."
           MAX_ATTEMPTS=15
           SLEEP_SEC=20

--- a/scripts/configure-caprover-app.sh
+++ b/scripts/configure-caprover-app.sh
@@ -382,6 +382,35 @@ elif [ "$APP_ALREADY_EXISTS" = "false" ] && [ -n "$DOMAINS" ]; then
   done
 fi
 
+# Post-update: force TS_HOSTNAME for build slots to prevent orphan values from
+# surviving across blue-green restore cycles.  swap-instances.sh only
+# force-overrides live/stable, not build — so a restore that restores stale
+# envVars onto the build slot would carry the orphan TS_HOSTNAME forward.
+if [[ "$APP_NAME" == *-build ]]; then
+  echo ""
+  echo "Build slot detected: forcing TS_HOSTNAME to app name..."
+  FORCE_DEFS=$(curl "${CURL_ARGS[@]}" -X GET "$CAPROVER_URL/api/v2/user/apps/appDefinitions" \
+    -H "x-captain-auth: $TOKEN")
+  FORCE_DEF=$(echo "$FORCE_DEFS" | jq --arg name "$APP_NAME" '.data.appDefinitions[] | select(.appName == $name)')
+  if [ -n "$FORCE_DEF" ] && [ "$FORCE_DEF" != "null" ]; then
+    FORCE_MERGED=$(echo "$FORCE_DEF" | jq --arg name "$APP_NAME" \
+      '.envVars = (((.envVars // []) | map(select(.key != "TS_HOSTNAME"))) + [{key: "TS_HOSTNAME", value: $name}])')
+    FORCE_RESPONSE=$(caprover_api_call "Force TS_HOSTNAME for build slot" \
+      curl "${CURL_ARGS[@]}" -X POST "$CAPROVER_URL/api/v2/user/apps/appDefinitions/update" \
+      -H "Content-Type: application/json" \
+      -H "x-captain-auth: $TOKEN" \
+      -d "$FORCE_MERGED")
+    FORCE_STATUS=$(echo "$FORCE_RESPONSE" | jq -r '.status')
+    if [ "$FORCE_STATUS" = "100" ] || [ "$FORCE_STATUS" = "1000" ]; then
+      echo "  TS_HOSTNAME=$APP_NAME"
+    else
+      echo "  Warning: TS_HOSTNAME force failed: $(echo "$FORCE_RESPONSE" | jq -r '.description')"
+    fi
+  else
+    echo "  Warning: could not fetch app definition for TS_HOSTNAME force"
+  fi
+fi
+
 echo ""
 echo "========================================="
 echo "Configuration complete: $APP_NAME"

--- a/scripts/tests/ts-hostname-build-slot.test.sh
+++ b/scripts/tests/ts-hostname-build-slot.test.sh
@@ -1,0 +1,110 @@
+#!/usr/bin/env bash
+# Sandbox test for bluegreen-residuals-300 Item 1:
+#   configure-caprover-app.sh force-overrides TS_HOSTNAME for build slots.
+# This is a jq-level dry-run — it tests the logic without a CapRover API call.
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+TMPDIR="$(mktemp -d)"
+trap 'rm -rf "$TMPDIR"' EXIT
+
+assert_eq() {
+  local name="$1" expected="$2" actual="$3"
+  if [ "$expected" = "$actual" ]; then
+    echo "ok - $name"
+  else
+    echo "not ok - $name"
+    echo "  expected: $expected"
+    echo "  actual:   $actual"
+    exit 1
+  fi
+}
+
+get_ts_hostname() {
+  echo "$1" | jq -r '.envVars[] | select(.key == "TS_HOSTNAME") | .value // ""'
+}
+
+# ── Test 1: orphan TS_HOSTNAME on build slot is corrected ──────────
+
+cat > "$TMPDIR/def1.json" <<'JSON'
+{
+  "appName": "qwickapps-documents-build",
+  "envVars": [
+    {"key": "PORT", "value": "3300"},
+    {"key": "TS_HOSTNAME", "value": "qwickapps-documents-prod"},
+    {"key": "TS_AUTHKEY", "value": "tskey-xxx"}
+  ]
+}
+JSON
+
+RESULT1=$(jq --arg name "qwickapps-documents-build" '
+  .envVars = (((.envVars // []) | map(select(.key != "TS_HOSTNAME"))) + [{key: "TS_HOSTNAME", value: $name}])
+' "$TMPDIR/def1.json")
+
+TS1=$(get_ts_hostname "$RESULT1")
+assert_eq "orphan TS_HOSTNAME corrected to app name" "qwickapps-documents-build" "$TS1"
+
+# ── Test 2: missing TS_HOSTNAME on build slot is added ────────────
+
+cat > "$TMPDIR/def2.json" <<'JSON'
+{
+  "appName": "qwickapps-mcp-build",
+  "envVars": [
+    {"key": "PORT", "value": "8080"},
+    {"key": "TS_AUTHKEY", "value": "tskey-yyy"}
+  ]
+}
+JSON
+
+RESULT2=$(jq --arg name "qwickapps-mcp-build" '
+  .envVars = (((.envVars // []) | map(select(.key != "TS_HOSTNAME"))) + [{key: "TS_HOSTNAME", value: $name}])
+' "$TMPDIR/def2.json")
+
+TS2=$(get_ts_hostname "$RESULT2")
+assert_eq "missing TS_HOSTNAME added as app name" "qwickapps-mcp-build" "$TS2"
+
+# ── Test 3: correct TS_HOSTNAME on build slot is preserved ────────
+
+cat > "$TMPDIR/def3.json" <<'JSON'
+{
+  "appName": "qwickapps-forge-build",
+  "envVars": [
+    {"key": "PORT", "value": "3300"},
+    {"key": "TS_HOSTNAME", "value": "qwickapps-forge-build"},
+    {"key": "TZ", "value": "UTC"}
+  ]
+}
+JSON
+
+RESULT3=$(jq --arg name "qwickapps-forge-build" '
+  .envVars = (((.envVars // []) | map(select(.key != "TS_HOSTNAME"))) + [{key: "TS_HOSTNAME", value: $name}])
+' "$TMPDIR/def3.json")
+
+TS3=$(get_ts_hostname "$RESULT3")
+assert_eq "correct TS_HOSTNAME kept as app name" "qwickapps-forge-build" "$TS3"
+
+# ── Test 4: non-build slot is not affected ─────────────────────────
+
+cat > "$TMPDIR/def4.json" <<'JSON'
+{
+  "appName": "qwickapps-documents-live",
+  "envVars": [
+    {"key": "TS_HOSTNAME", "value": "qwickapps-documents-live"}
+  ]
+}
+JSON
+
+# Simulate the guard: only apply when appName ends with -build
+RESULT4=$(echo "$(cat "$TMPDIR/def4.json")" | jq --arg name "qwickapps-documents-live" '
+  if ($name | endswith("-build")) then
+    .envVars = (((.envVars // []) | map(select(.key != "TS_HOSTNAME"))) + [{key: "TS_HOSTNAME", value: $name}])
+  else
+    .
+  end
+')
+
+TS4=$(get_ts_hostname "$RESULT4")
+assert_eq "non-build slot unchanged" "qwickapps-documents-live" "$TS4"
+
+echo ""
+echo "All TS_HOSTNAME build-slot tests passed."


### PR DESCRIPTION
Context: post-restore residuals from documents blue-green restore (protocols#300).

Item 1: configure-caprover-app.sh now detects build slots and force-overrides TS_HOSTNAME to the app name. swap-instances.sh only force-overrides live/stable, so a restore that restores stale envVars onto the build slot would carry the orphan TS_HOSTNAME forward.

Item 2: Validate live slot health step was probing the CapRover public domain (404 before domain is bound). Changed to use Tailnet MagicDNS (taile324e7.ts.net:8080).

Sandbox test: scripts/tests/ts-hostname-build-slot.test.sh covers orphan override, missing-add, correct-preserve, and non-build guard.

Closes qwickapps/protocols#300