### PR TITLE
fix(deploy-app): add GHCR login to verify-provenance job

### DIFF
--- a/.github/workflows/deploy-app.yml
+++ b/.github/workflows/deploy-app.yml
@@ -427,6 +427,11 @@ jobs:
       (needs.build.result == 'success' || needs.build.result == 'skipped')
     runs-on: [self-hosted, macmini]
     steps:
+      - name: Login to GHCR
+        env:
+          GHCR_TOKEN: ${{ secrets.GHCR_PUSH_TOKEN || secrets.GITHUB_TOKEN }}
+        run: |
+          echo "$GHCR_TOKEN" | docker login ghcr.io -u "${{ github.actor }}" --password-stdin
       - name: Check image references exist
         run: |
           set -euo pipefail


### PR DESCRIPTION
## Summary
The \`verify-provenance\` job runs \`docker buildx imagetools inspect\` to confirm the built image exists in ghcr.io, but it had no docker login step. The \`build\` job creates a per-job temp docker config (\`$TMPDIR_DOCKER\`) that doesn't carry over to subsequent jobs, so imagetools inspect failed with \`401 Unauthorized\` on every deploy.

Add a "Login to GHCR" step using \`GHCR_PUSH_TOKEN || GITHUB_TOKEN\`, matching the pattern used in the \`build\` job's login.

## Test plan
- [ ] Deploy qwickapps-mcp verify-provenance passes
- [ ] No regression on uat/live/stable stage promotions