### PR TITLE
fix(deploy-app): guard empty CMD_ARGS against bash nounset

### DIFF
--- a/.github/workflows/deploy-app.yml
+++ b/.github/workflows/deploy-app.yml
@@ -569,7 +569,7 @@ jobs:
             --caprover-password "$CAPROVER_PASSWORD" \
             --container-port "${{ inputs.container_port }}" \
             --env-file "$ENV_FILE" \
-            "${CMD_ARGS[@]}"
+            "${CMD_ARGS[@]+"${CMD_ARGS[@]}"}"
 
       - name: Deploy image to target slot
         run: |


### PR DESCRIPTION
## Summary
bash 3.2 (macOS default, used by self-hosted macmini runner) treats `${array[@]}` as unbound when the array is empty and `set -u` is active. When no `--cmd` input is provided, `CMD_ARGS` stays empty and `"${CMD_ARGS[@]}"` triggers: `CMD_ARGS[@]: unbound variable`.

Fix: use the `${var+alt}` expansion to pass the array only when non-empty: `"${CMD_ARGS[@]+"${CMD_ARGS[@]}"}"`.

## Test plan
- [ ] deploy-caprover "Configure target slot" step succeeds without --cmd input