### PR TITLE
fix(evidence-gate): pass unchecked_items via env to avoid backtick command substitution

### DIFF
--- a/.github/workflows/validation-evidence-gate.yml
+++ b/.github/workflows/validation-evidence-gate.yml
@@ -146,10 +146,9 @@ jobs:
         if: steps.classify.outputs.fleet_critical == 'true' && steps.parse.outputs.has_section == 'true' && steps.parse.outputs.unchecked_count != '0' && steps.parse.outputs.unchecked_count != ''
         env:
           GH_TOKEN: ${{ github.token }}
+          ITEMS: ${{ steps.parse.outputs.unchecked_items }}
         run: |
           set -euo pipefail
-
-          ITEMS="${{ steps.parse.outputs.unchecked_items }}"
 
           ITEM_LIST=""
           while IFS= read -r entry; do


### PR DESCRIPTION
## Summary

- Fixes exit 126 crash when PR test plan items contain backtick-formatted code (e.g. `` `~/.qwickapps/protocols/core-principles.md` ``)
- Root cause: `${{ steps.parse.outputs.unchecked_items }}` was inlined directly into the shell script by GitHub Actions; backticks in the value landed as literal shell source text → bash interpreted them as command substitution → tried to execute the markdown path → Permission denied → exit 126
- Fix: move `unchecked_items` to `env:` block so it's passed as an environment variable (content never shell-interpreted)

## Root cause detail

GitHub Actions resolves `${{ expr }}` **before** the shell runs, splicing the value literally into the script. When `unchecked_items` contains `` `file.md` ``, the shell sees:

```bash
ITEMS="1:- [ ] Read `~/.qwickapps/protocols/core-principles.md`"
#                   ↑ bash command substitution ↑
```

Environment variables, by contrast, are passed to the shell as data — their content is never re-parsed as shell code.

## Affected PRs

Reproduced on protocols#591, #592, #593 (all have backtick-wrapped paths in test plan).

## Test plan

- [ ] Merge this PR
- [ ] Re-run CI on one of protocols#591/592/593 — evidence gate should no longer exit 126
- [ ] Verify the gate still correctly fails on genuinely unchecked items (no regression)

🤖 Generated with [Claude Code](https://claude.com/claude-code)