### PR TITLE
fix(deploy-app): restore deploy fallbacks

### DIFF
--- a/.github/workflows/deploy-app.yml
+++ b/.github/workflows/deploy-app.yml
@@ -324,10 +324,10 @@ jobs:
     steps:
       - name: Download rendered env file artifact (if present)
         uses: actions/download-artifact@v4
+        continue-on-error: true
         with:
           name: app-env-${{ inputs.environment }}-${{ inputs.app_name }}
           path: .deploy-app-env
-          if-no-files-found: ignore
 
       - name: Resolve env file path
         id: env-file
@@ -452,7 +452,7 @@ jobs:
     steps:
       - name: Login to GHCR
         run: |
-          echo "${{ secrets.GITHUB_TOKEN }}" | docker login ghcr.io -u ${{ github.actor }} --password-stdin
+          echo "${{ secrets.GHCR_PUSH_TOKEN || secrets.GITHUB_TOKEN }}" | docker login ghcr.io -u ${{ github.actor }} --password-stdin
       - name: Check image references exist
         run: |
           set -euo pipefail
@@ -543,10 +543,10 @@ jobs:
 
       - name: Download rendered env file artifact (if present)
         uses: actions/download-artifact@v4
+        continue-on-error: true
         with:
           name: app-env-${{ inputs.environment }}-${{ inputs.app_name }}
           path: .deploy-app-env
-          if-no-files-found: ignore
 
       - name: Resolve env file path
         id: env-file
@@ -830,10 +830,10 @@ jobs:
 
       - name: Download rendered env file artifact (if present)
         uses: actions/download-artifact@v4
+        continue-on-error: true
         with:
           name: app-env-${{ inputs.environment }}-${{ inputs.app_name }}
           path: .deploy-app-env
-          if-no-files-found: ignore
 
       - name: Resolve env file path
         id: env-file


### PR DESCRIPTION
ATTN fleet-lead

## Summary
- Removed the invalid `if-no-files-found: ignore` input from the `actions/download-artifact@v4` steps in `validate-env`, `deploy-caprover`, and `deploy-stable`.
- Added `continue-on-error: true` to those artifact download steps so the existing env-file candidate loop can handle absent artifacts during caller migration.
- Restored the `secrets.GHCR_PUSH_TOKEN || secrets.GITHUB_TOKEN` fallback for the `verify-provenance` GHCR login.

## Root Cause
PR #89 introduced an unsupported `actions/download-artifact@v4` input and removed the PAT fallback needed for cross-repo private GHCR package reads. The expired PAT caused the earlier 401, but the refreshed PAT remains the correct credential path for `img-qwickapps-forge`.

Fixes #91.

## Validation
- `actionlint -shellcheck= -config-file .github/actionlint.yaml .github/workflows/deploy-app.yml`
- `bash scripts/tests/contract.test.sh`
- `bash scripts/tests/blue-green-workflow-guard.test.sh`
- `bash scripts/tests/validation-evidence-gate.test.sh`
- `bash scripts/tests/validate-env-values.test.sh`
- `bash scripts/tests/ts-hostname-build-slot.test.sh`
- Targeted grep check confirmed no remaining `if-no-files-found` entries and the expected fallback expressions.

Note: full `actionlint -config-file .github/actionlint.yaml .github/workflows/deploy-app.yml` still reports pre-existing shellcheck diagnostics at `.github/workflows/deploy-app.yml:176` and `.github/workflows/deploy-app.yml:595`; those lines are outside this change.
