### PR TITLE
fix(deploy-app): disable provenance attestation to unblock builds

### DIFF
--- a/.github/workflows/deploy-app.yml
+++ b/.github/workflows/deploy-app.yml
@@ -438,6 +438,7 @@ jobs:
           file: ${{ inputs.dockerfile_path }}
           push: true
           platforms: linux/arm64
+          provenance: false
           tags: |
             ${{ needs.resolve-stage.outputs.image_ref }}
 


### PR DESCRIPTION
## Summary
- Adds `provenance: false` to `docker/build-push-action` inputs in the "Build and push immutable image" step
- Prevents the action from uploading a provenance attestation artifact to GitHub Actions storage
- When the org artifact quota is full, this upload fails and blocks the entire build job even though the Docker image itself built and pushed to GHCR successfully

## Closes
ci-workflows#94

## Impact
Forge has been DOWN 9 days due to this blocking issue. This is the final fix.