### PR TITLE
[codex] Login to GHCR before Buildx setup

### DIFF
--- a/.github/workflows/deploy-app.yml
+++ b/.github/workflows/deploy-app.yml
@@ -428,9 +428,13 @@ jobs:
 
       - name: Login to GHCR for base image pull
         run: |
-          echo "$GHCR_TOKEN" | $DOCKER_CLI login ghcr.io -u raajkumars --password-stdin
+          _cli="${DOCKER_CLI:-docker}"
+          # Use env -u DOCKER_CONFIG so credentials write to ~/.docker/config.json
+          # (the persistent path the BuildKit container can inherit), not the
+          # ephemeral DOCKER_CONFIG temp dir set by the previous Login to GHCR step.
+          echo "$GHCR_PULL_TOKEN" | env -u DOCKER_CONFIG "$_cli" login ghcr.io -u "${{ github.actor }}" --password-stdin
         env:
-          GHCR_TOKEN: ${{ secrets.GHCR_TOKEN }}
+          GHCR_PULL_TOKEN: ${{ secrets.GHCR_PULL_TOKEN }}
           DOCKER_CLI: ${{ env.DOCKER_CLI }}
 
       - name: Set up Docker Buildx

--- a/.github/workflows/deploy-app.yml
+++ b/.github/workflows/deploy-app.yml
@@ -415,11 +415,12 @@ jobs:
         env:
           GHCR_TOKEN: ${{ secrets.GHCR_PUSH_TOKEN || secrets.GITHUB_TOKEN }}
         run: |
-          TMPDIR_DOCKER="$(mktemp -d)"
+          DOCKER_CONFIG="${RUNNER_TEMP}/.docker-persistent"
+          mkdir -p "$DOCKER_CONFIG"
           AUTH_B64=$(printf '%s:%s' "${{ github.actor }}" "$GHCR_TOKEN" | base64 | tr -d '\n')
-          printf '{"auths":{"ghcr.io":{"auth":"%s"}}}\n' "$AUTH_B64" > "$TMPDIR_DOCKER/config.json"
-          echo "DOCKER_CONFIG=$TMPDIR_DOCKER" >> "$GITHUB_ENV"
-          echo "GHCR credentials wrote to $TMPDIR_DOCKER/config.json"
+          printf '{"auths":{"ghcr.io":{"auth":"%s"}}}\n' "$AUTH_B64" > "$DOCKER_CONFIG/config.json"
+          echo "DOCKER_CONFIG=$DOCKER_CONFIG" >> "$GITHUB_ENV"
+          echo "GHCR credentials wrote to $DOCKER_CONFIG/config.json"
 
       - name: Clean up stale buildx builders
         run: |
@@ -429,13 +430,11 @@ jobs:
       - name: Login to GHCR for base image pull
         run: |
           _cli="${DOCKER_CLI:-docker}"
-          # Use env -u DOCKER_CONFIG so credentials write to ~/.docker/config.json
-          # (the persistent path the BuildKit container can inherit), not the
-          # ephemeral DOCKER_CONFIG temp dir set by the previous Login to GHCR step.
-          echo "$GHCR_PULL_TOKEN" | env -u DOCKER_CONFIG "$_cli" login ghcr.io -u "${{ github.actor }}" --password-stdin
+          echo "$GHCR_TOKEN" | "$_cli" login ghcr.io -u "${{ github.actor }}" --password-stdin
         env:
-          GHCR_PULL_TOKEN: ${{ secrets.GHCR_PULL_TOKEN }}
+          GHCR_TOKEN: ${{ secrets.GHCR_PULL_TOKEN }}
           DOCKER_CLI: ${{ env.DOCKER_CLI }}
+          DOCKER_CONFIG: ${{ runner.temp }}/.docker-persistent
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3

--- a/.github/workflows/deploy-app.yml
+++ b/.github/workflows/deploy-app.yml
@@ -427,13 +427,11 @@ jobs:
           docker buildx rm --all-inactive --force 2>/dev/null || true
 
       - name: Login to GHCR for base image pull
-        if: ${{ env.DOCKER_CLI != '' }}
         run: |
           echo "$GHCR_TOKEN" | $DOCKER_CLI login ghcr.io -u raajkumars --password-stdin
         env:
           GHCR_TOKEN: ${{ secrets.GHCR_TOKEN }}
           DOCKER_CLI: ${{ env.DOCKER_CLI }}
-          DOCKER_HOST: ${{ env.DOCKER_HOST }}
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3

--- a/.github/workflows/deploy-app.yml
+++ b/.github/workflows/deploy-app.yml
@@ -426,6 +426,15 @@ jobs:
           docker ps -a --filter name=buildx_buildkit_ --format '{{.Names}}' | xargs -r docker rm -f 2>/dev/null || true
           docker buildx rm --all-inactive --force 2>/dev/null || true
 
+      - name: Login to GHCR for base image pull
+        if: ${{ env.DOCKER_CLI != '' }}
+        run: |
+          echo "$GHCR_TOKEN" | $DOCKER_CLI login ghcr.io -u raajkumars --password-stdin
+        env:
+          GHCR_TOKEN: ${{ secrets.GHCR_TOKEN }}
+          DOCKER_CLI: ${{ env.DOCKER_CLI }}
+          DOCKER_HOST: ${{ env.DOCKER_HOST }}
+
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
         with:


### PR DESCRIPTION
## Summary

Adds an explicit GHCR login step in `.github/workflows/deploy-app.yml` after stale Buildx builder cleanup and before `docker/setup-buildx-action@v3`.

## Root Cause

The `docker-container` Buildx driver runs BuildKit in a container that does not inherit the host runner's ephemeral `DOCKER_CONFIG` temp directory. The existing GHCR credentials are written under `/tmp`, so BuildKit cannot access them when pulling `ghcr.io/qwickapps/img-node:latest`, resulting in `denied: denied`.

## Impact

The new step logs in with the resolved Docker CLI in the build job, using `GHCR_TOKEN`, so the Buildx container can inherit credentials needed to pull GHCR base images.

References ci-workflows#98.

## Validation

- `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/deploy-app.yml"); puts "YAML OK"'`
- `actionlint .github/workflows/deploy-app.yml` (reported existing shellcheck findings at lines 176 and 605; no new workflow syntax issue from this change)
- `git diff --check`