### PR TITLE
fix(attribution): change default ATTRIBUTION_MODE from fail to warn

### DIFF
--- a/scripts/attribution-check.sh
+++ b/scripts/attribution-check.sh
@@ -25,7 +25,7 @@ set -euo pipefail
 
 BASE_SHA="${BASE_SHA:-${1:-}}"
 HEAD_SHA="${HEAD_SHA:-${2:-}}"
-ATTRIBUTION_MODE="${ATTRIBUTION_MODE:-fail}"
+ATTRIBUTION_MODE="${ATTRIBUTION_MODE:-warn}"
 
 # Patterns to detect AI co-authorship in commit trailers
 AI_PATTERNS=(


### PR DESCRIPTION
Closes #90\n\nChanges ATTRIBUTION_MODE default from fail to warn so AI-authored PRs from the qwickapps fleet can pass CI. The check still runs and logs AI attribution for traceability.