### PR TITLE
fix(deploy-app): use temp DOCKER_CONFIG to avoid osxkeychain on headless runners

### DIFF
--- a/.github/workflows/deploy-app.yml
+++ b/.github/workflows/deploy-app.yml
@@ -460,9 +460,12 @@ jobs:
       needs.resolve-stage.result == 'success' &&
       (needs.build.result == 'success' || needs.build.result == 'skipped')
     runs-on: [self-hosted, macmini]
+    env:
+      DOCKER_CONFIG: /tmp/docker-cfg-${{ github.run_id }}
     steps:
       - name: Login to GHCR
         run: |
+          mkdir -p "$DOCKER_CONFIG"
           echo "${{ secrets.GHCR_PUSH_TOKEN || secrets.GITHUB_TOKEN }}" | docker login ghcr.io -u ${{ github.actor }} --password-stdin
       - name: Check image references exist
         run: |


### PR DESCRIPTION
Closes #103

Sets DOCKER_CONFIG to a per-run temp directory in the verify-provenance job so docker login stores credentials in a plain JSON file instead of the macOS keychain. Fixes deploy failures on headless macOS runners.