### PR TITLE
fix(main-push-guard): use RUNNER_TEMP persistent docker config — fix 'denied: denied' GHCR push

### DIFF
--- a/workflows/main-push-guard.yml
+++ b/workflows/main-push-guard.yml
@@ -138,8 +138,6 @@ jobs:
     permissions:
       contents: read
       packages: write
-    env:
-      DOCKER_CONFIG: /tmp/docker-config-${{ github.run_id }}
     outputs:
       image_ref: ${{ steps.meta.outputs.image_ref }}
       image_tag: ${{ steps.meta.outputs.tag }}
@@ -159,12 +157,16 @@ jobs:
           echo "tag=${TAG}" >> "$GITHUB_OUTPUT"
           echo "Image: ${IMAGE}"
 
+      - name: Prepare persistent docker config dir
+        run: |
+          mkdir -p "${RUNNER_TEMP}/.docker-persistent"
+          echo "DOCKER_CONFIG=${RUNNER_TEMP}/.docker-persistent" >> "$GITHUB_ENV"
+
       - name: Log in to GHCR
-        uses: docker/login-action@v3
-        with:
-          registry: ${{ env.REGISTRY }}
-          username: ${{ github.actor }}
-          password: ${{ secrets.GHCR_PUSH_TOKEN }}
+        env:
+          GHCR_TOKEN: ${{ secrets.GHCR_PUSH_TOKEN }}
+        run: |
+          echo "$GHCR_TOKEN" | docker login ghcr.io -u "${{ github.actor }}" --password-stdin
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3


### PR DESCRIPTION
## Summary

- Same root cause and fix as #99, applied to `main-push-guard.yml`
- `DOCKER_CONFIG=/tmp/docker-config-$run_id` was using an ephemeral mktemp-style path
- On self-hosted macmini runners with Docker Desktop, the buildx container driver cannot see this path, causing `failed to fetch oauth token: denied: denied` at push time
- Fix: use `RUNNER_TEMP/.docker-persistent` (consistent with #99's fix in deploy-app.yml) + explicit `docker login --password-stdin` instead of `docker/login-action`

## Evidence

mcp/build run 27736944357 fails at `build-once / Build and Push Docker Image`:
```
ERROR: failed to authorize: failed to fetch oauth token: denied: denied
ERROR: failed to build: failed to solve: failed to fetch oauth token: denied: denied
```

This is the mcp build-push job calling `main-push-guard.yml@main`. The same token works fine when `deploy-app.yml` uses the RUNNER_TEMP path (per #99).

## Test plan
- [x] CI passes on this PR
- [x] SKIP: E2E push test — requires triggering a full mcp build; will be validated on the next mcp main push after merge