### PR TITLE
fix(verify-provenance): use docker/login-action + GHCR_PULL_TOKEN

### DIFF
--- a/.github/workflows/deploy-app.yml
+++ b/.github/workflows/deploy-app.yml
@@ -460,8 +460,6 @@ jobs:
       needs.resolve-stage.result == 'success' &&
       (needs.build.result == 'success' || needs.build.result == 'skipped')
     runs-on: [self-hosted, macmini]
-    env:
-      DOCKER_CONFIG: /tmp/docker-cfg-${{ github.run_id }}
     steps:
       - name: Login to GHCR
         uses: docker/login-action@v3

--- a/.github/workflows/deploy-app.yml
+++ b/.github/workflows/deploy-app.yml
@@ -464,9 +464,11 @@ jobs:
       DOCKER_CONFIG: /tmp/docker-cfg-${{ github.run_id }}
     steps:
       - name: Login to GHCR
-        run: |
-          mkdir -p "$DOCKER_CONFIG"
-          echo "${{ secrets.GHCR_PUSH_TOKEN || secrets.GITHUB_TOKEN }}" | docker login ghcr.io -u ${{ github.actor }} --password-stdin
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GHCR_PULL_TOKEN }}
       - name: Check image references exist
         run: |
           set -euo pipefail


### PR DESCRIPTION
## Summary

Replace raw `docker login` in `verify-provenance` with `docker/login-action@v3` + `GHCR_PULL_TOKEN`, matching the pattern established in PR #99 for the build job.

The raw login with `GHCR_PUSH_TOKEN || GITHUB_TOKEN` was using credential isolation that prevented Docker daemon from reaching the persistent config, causing `denied: denied`.

Closes #106