### PR TITLE
fix(main-push-guard): make GHCR_PUSH_TOKEN optional + add GITHUB_TOKEN fallback

### DIFF
--- a/.github/workflows/main-push-guard.yml
+++ b/.github/workflows/main-push-guard.yml
@@ -38,7 +38,7 @@ on:
         default: true
     secrets:
       GHCR_PUSH_TOKEN:
-        required: true
+        required: false
 
 env:
   REGISTRY: ghcr.io
@@ -209,7 +209,7 @@ jobs:
         # auth straight into the isolated DOCKER_CONFIG so buildx pushes with it
         # and `docker login` is never called.
         env:
-          GHCR_TOKEN: ${{ secrets.GHCR_PUSH_TOKEN }}
+          GHCR_TOKEN: ${{ secrets.GHCR_PUSH_TOKEN || secrets.GITHUB_TOKEN }}
         run: |
           mkdir -p "$DOCKER_CONFIG"
           AUTH="$(printf '%s:%s' '${{ github.actor }}' "$GHCR_TOKEN" | base64 | tr -d '\n')"


### PR DESCRIPTION
## Summary

Two-line change to unblock builds when \`GHCR_PUSH_TOKEN\` is invalid or expired:

1. \`GHCR_PUSH_TOKEN: required: true\` → \`required: false\`
2. \`GHCR_TOKEN: ${{ secrets.GHCR_PUSH_TOKEN }}\` → \`${{ secrets.GHCR_PUSH_TOKEN || secrets.GITHUB_TOKEN }}\`

\`GITHUB_TOKEN\` has \`packages: write\` in all calling workflows — for same-org pushes (\`qwickapps/*\` → \`ghcr.io/qwickapps/...\`) it always works. Repos with a valid \`GHCR_PUSH_TOKEN\` are unaffected (token is still preferred when present).

Matches the fallback pattern already used throughout \`deploy-app.yml\`.

Closes #108