### PR TITLE
fix(verify-provenance): restore DOCKER_CONFIG + raw docker login (revert PR#107 regression)

### DIFF
--- a/.github/workflows/deploy-app.yml
+++ b/.github/workflows/deploy-app.yml
@@ -460,13 +460,15 @@ jobs:
       needs.resolve-stage.result == 'success' &&
       (needs.build.result == 'success' || needs.build.result == 'skipped')
     runs-on: [self-hosted, macmini]
+    env:
+      DOCKER_CONFIG: /tmp/docker-vp-${{ github.run_id }}
     steps:
       - name: Login to GHCR
-        uses: docker/login-action@v3
-        with:
-          registry: ghcr.io
-          username: ${{ github.actor }}
-          password: ${{ secrets.GHCR_PULL_TOKEN }}
+        env:
+          GHCR_TOKEN: ${{ secrets.GHCR_PULL_TOKEN || secrets.GITHUB_TOKEN }}
+        run: |
+          mkdir -p "$DOCKER_CONFIG"
+          echo "$GHCR_TOKEN" | docker login ghcr.io -u "${{ github.actor }}" --password-stdin
       - name: Check image references exist
         run: |
           set -euo pipefail


### PR DESCRIPTION
## Problem

PR#107 switched `verify-provenance` to `docker/login-action@v3` and removed the `DOCKER_CONFIG` env var, causing `errSecInteractionNotAllowed (-25308)` on headless macmini runners.

Confirmed failing: run 27737987111 (2026-06-18T05:10Z).

## Fix

Restore the pattern from PR#104 (which correctly fixed the same issue via ci-workflows#103):
- Add `DOCKER_CONFIG: /tmp/docker-vp-${{ github.run_id }}` at job level
- Switch from `docker/login-action@v3` back to raw `docker login` via `--password-stdin`
- Add `|| secrets.GITHUB_TOKEN` fallback (GHCR_PULL_TOKEN last updated 2026-04-07)

## Why

`docker/login-action@v3` on macOS headless runner uses the system keychain (`osxkeychain`). Without `DOCKER_CONFIG` override pointing to a temp dir, it fails: `User interaction is not allowed. (-25308)`.

Raw `docker login` + `DOCKER_CONFIG` env writes credentials to a plain JSON file, bypassing the keychain. This is the established pattern in `main-push-guard.yml` (after PR#105).

Closes #110