### PR TITLE
fix(verify-provenance): disable osxkeychain before GHCR login on macOS runners

### DIFF
--- a/.github/workflows/deploy-app.yml
+++ b/.github/workflows/deploy-app.yml
@@ -468,6 +468,7 @@ jobs:
           GHCR_TOKEN: ${{ secrets.GHCR_PULL_TOKEN || secrets.GITHUB_TOKEN }}
         run: |
           mkdir -p "$DOCKER_CONFIG"
+          printf '{"credsStore":""}' > "$DOCKER_CONFIG/config.json"
           echo "$GHCR_TOKEN" | docker login ghcr.io -u "${{ github.actor }}" --password-stdin
       - name: Check image references exist
         run: |

--- a/.github/workflows/deploy-app.yml
+++ b/.github/workflows/deploy-app.yml
@@ -460,13 +460,15 @@ jobs:
       needs.resolve-stage.result == 'success' &&
       (needs.build.result == 'success' || needs.build.result == 'skipped')
     runs-on: [self-hosted, macmini]
+    env:
+      DOCKER_CONFIG: /tmp/docker-vp-${{ github.run_id }}
     steps:
       - name: Login to GHCR
-        uses: docker/login-action@v3
-        with:
-          registry: ghcr.io
-          username: ${{ github.actor }}
-          password: ${{ secrets.GHCR_PULL_TOKEN }}
+        env:
+          GHCR_TOKEN: ${{ secrets.GHCR_PULL_TOKEN || secrets.GITHUB_TOKEN }}
+        run: |
+          mkdir -p "$DOCKER_CONFIG"
+          echo "$GHCR_TOKEN" | docker login ghcr.io -u "${{ github.actor }}" --password-stdin
       - name: Check image references exist
         run: |
           set -euo pipefail


### PR DESCRIPTION
## Problem

\`verify-provenance\` fails on macOS self-hosted runners with:
\`\`\`
error saving credentials: error storing credentials - err: exit status 1, out: \`User interaction is not allowed. (-25308)\`
\`\`\`

Root cause: \`docker login\` defaults to \`osxkeychain\` credential store on macOS when no \`credsStore\` is configured. The \`DOCKER_CONFIG=/tmp/docker-vp-<run_id>\` directory is created empty (\`mkdir -p\`), so Docker falls back to the macOS default (keychain), which requires GUI interaction in CI.

## Why build-and-push works

\`build-and-push\` uses \`DOCKER_CONFIG=/tmp/docker-ci\` which is pre-seeded by an earlier step with a \`config.json\` that stores auth inline (no \`credsStore\`). \`verify-provenance\` creates a fresh empty dir each run.

## Fix

Write \`{"credsStore":""}\` to \`DOCKER_CONFIG/config.json\` before \`docker login\` so credentials are stored inline in the file rather than via keychain.

## Test plan

- [ ] SKIP: deferred to live run — db deploy verify-provenance passes after merge

## Validation debt

Fix is mechanical (one line before docker login). Breakage is immediately visible on any db deploy verify-provenance step.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
https://claude.ai/code/session_015U83WabzFiFDPUhPhRgyku