### PR TITLE
fix(verify-provenance): write GHCR credentials directly to bypass osxkeychain (-25308)

### DIFF
--- a/.github/workflows/deploy-app.yml
+++ b/.github/workflows/deploy-app.yml
@@ -463,12 +463,13 @@ jobs:
     env:
       DOCKER_CONFIG: /tmp/docker-vp-${{ github.run_id }}
     steps:
-      - name: Login to GHCR
+      - name: Write GHCR credentials directly (bypasses osxkeychain on headless runner)
         env:
           GHCR_TOKEN: ${{ secrets.GHCR_PULL_TOKEN || secrets.GITHUB_TOKEN }}
         run: |
           mkdir -p "$DOCKER_CONFIG"
-          echo "$GHCR_TOKEN" | docker login ghcr.io -u "${{ github.actor }}" --password-stdin
+          AUTH_B64=$(printf '%s:%s' "${{ github.actor }}" "$GHCR_TOKEN" | base64 | tr -d '\n')
+          printf '{"auths":{"ghcr.io":{"auth":"%s"}}}\n' "$AUTH_B64" > "$DOCKER_CONFIG/config.json"
       - name: Check image references exist
         run: |
           set -euo pipefail


### PR DESCRIPTION
## Problem

`docker login` on macOS tries to save credentials via `osxkeychain` regardless of the `DOCKER_CONFIG` path. On headless CI runners, the keychain requires GUI interaction → fails with `-25308 (User interaction is not allowed)`.

Confirmed still failing in run 27738313839 even with `DOCKER_CONFIG=/tmp/docker-vp-<run_id>` override.

## Root cause

When `DOCKER_CONFIG` points to a directory with no `config.json`, `docker login` creates a new config.json with `"credsStore": "osxkeychain"` as the default on macOS. The credential save then fails on headless runners.

## Fix

Write the `config.json` directly with base64-encoded auth (same pattern used by the `build` job at line 418-423). This bypasses all credential store machinery.

```bash
AUTH_B64=$(printf '%s:%s' "$actor" "$TOKEN" | base64 | tr -d '\n')
printf '{"auths":{"ghcr.io":{"auth":"%s"}}}\n' "$AUTH_B64" > "$DOCKER_CONFIG/config.json"
```

## Context

- PR#104 established this pattern for the build job ✅  
- PR#107 switched verify-provenance to `docker/login-action@v3` → broke it (osxkeychain)
- PR#111 switched back to `docker login --password-stdin` → still broke it (osxkeychain on save)
- This PR: use direct credential write, consistent with the build job

Supersedes #110 (same issue, better fix).