### PR TITLE
ci: add ghcr pre-flight reachability probe

### DIFF
--- a/workflows/main-push-guard.yml
+++ b/workflows/main-push-guard.yml
@@ -162,6 +162,18 @@ jobs:
           mkdir -p "${RUNNER_TEMP}/.docker-persistent"
           echo "DOCKER_CONFIG=${RUNNER_TEMP}/.docker-persistent" >> "$GITHUB_ENV"
 
+      - name: Pre-flight: verify ghcr.io reachability
+        run: |
+          if curl --fail --max-time 10 --retry 2 --retry-delay 3 -sI https://ghcr.io 2>/dev/null; then
+            echo "ghcr.io reachable"
+          else
+            echo "❌ ghcr.io is unreachable from this runner"
+            echo "   Root cause: macmini Tailscale exit-node may be down"
+            echo "   Fix: SSH to macmini and run: tailscale up"
+            echo "   (or wait for the Tailscale keep-alive launchd agent to recover)"
+            exit 1
+          fi
+
       - name: Log in to GHCR
         env:
           GHCR_TOKEN: ${{ secrets.GHCR_PUSH_TOKEN }}


### PR DESCRIPTION
## Summary
- Add a pre-flight connectivity probe for `ghcr.io` immediately before the `Log in to GHCR` step.
- Fail fast with clear diagnostics that point to a possible macmini Tailscale exit-node issue.
- Keep total probe latency bounded with the provided retry and timeout controls.

## Test plan with all items checked [x]
- [x] Confirm the workflow now has a `Pre-flight: verify ghcr.io reachability` step immediately before `Log in to GHCR` in `workflows/main-push-guard.yml`.
- [x] Confirm the probe command is exactly `curl --fail --max-time 10 --retry 2 --retry-delay 3 -sI https://ghcr.io 2>/dev/null`.
- [x] Confirm failure path prints the required triage message and exits non-zero.

## Validation debt
None
